### PR TITLE
feat(web): 应用屏蔽到论坛文章标题

### DIFF
--- a/web/src/pages/forum/Forum.vue
+++ b/web/src/pages/forum/Forum.vue
@@ -17,6 +17,9 @@ const router = useRouter();
 const message = useMessage();
 
 const { whoami } = Locator.authRepository();
+const blockUserCommentRepository = Locator.blockUserCommentRepository();
+const isBlocked = (userName: string) =>
+  blockUserCommentRepository.ref.value.usernames.includes(userName);
 
 const articleCategoryOptions = [
   { value: 'General', label: '小说交流' },
@@ -143,13 +146,18 @@ const deleteArticle = (article: ArticleSimplified) =>
                 />
                 <c-a :to="`/forum/${article.id}`">
                   <n-text v-if="article.hidden" depth="3">[隐藏]</n-text>
-                  <b>{{ article.title }}</b>
+                  <n-text
+                    v-else-if="isBlocked(article.user.username)"
+                    depth="3"
+                  >
+                    [屏蔽]
+                  </n-text>
+                  <b v-else>{{ article.title }}</b>
                 </c-a>
               </n-flex>
               <n-text style="font-size: 12px">
-                {{
-                  article.updateAt === article.createAt ? '发布' : '更新'
-                }}于<n-time :time="article.updateAt * 1000" type="relative" />
+                {{ article.updateAt === article.createAt ? '发布' : '更新' }}于
+                <n-time :time="article.updateAt * 1000" type="relative" />
                 by {{ article.user.username }}
               </n-text>
 


### PR DESCRIPTION
将 #174 中的屏蔽功能扩展到论坛界面的标题, 但并未对内文做任何改动, 也没有添加新的按钮, 仅隐藏标题, 屏蔽依旧需要先找到用户的评论再进行操作