### PR TITLE
chore: 修復開發環境路徑解析

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint src",
     "lint:dist": "eslint dist",
     "test": "vitest run",
-    "prepare": "cd .. && husky web/.husky || true"
+    "prepare": "cd .. && husky web/.husky || true",
+    "clean": "vue-tsc --build --clean"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/web/src/util/useUserData/api.ts
+++ b/web/src/util/useUserData/api.ts
@@ -1,11 +1,17 @@
 import ky from 'ky';
 
 export const AuthUrl = (() => {
-  const { protocol, host } = window.location;
+  const { protocol, hostname, host, origin } = window.location;
 
   // 让 kuriko 的开发环境可以跑起来，后续需要支持开发环境免登录
-  if (host.startsWith('localhost:')) {
-    return `${protocol}//localhost:8000`;
+  const isLocalHost =
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '0.0.0.0' ||
+    hostname === '[::1]';
+
+  if (isLocalHost) {
+    return origin;
   }
 
   // 不考虑 a.co.uk 这种顶级域名

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -9,6 +9,8 @@ import { defineConfig, loadEnv } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+import path from 'path';
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
   const apiMode = env.VITE_API_MODE;
@@ -25,6 +27,11 @@ export default defineConfig(({ mode }) => {
   const enableSonda = env.VITE_ENABLE_SONDA === 'true';
 
   const config: UserConfig = {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+      },
+    },
     build: {
       target: ['es2015'],
       cssCodeSplit: false,


### PR DESCRIPTION
### 修改
- 在 vite 設定新增 `@ -> src` alias
- 重構「跳過登入驗證」的本機環境判斷，擴充支援`localhost`、`127.0.0.1`、`0.0.0.0`、`[::1]`等常用 loopback 位址
- 確認為本機環境後返回原先頁面，避免寫死 host/port
- 在`package.json`新增`clean` script，用於快速清理 vite 的編譯檔案 (`pnpm clean`)

### 原因
- vite 編譯會失敗
- 舊邏輯對 host/port 的假設過強
- 缺少清理指令，影響開發流程

### 影響
- 改善前端開發流程與環境穩定性
- 預期不影響正式環境