### PR TITLE
feat(web): 为 vite proxy 增加代理能力

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       pretty-quick:
         specifier: ^4.2.2
         version: 4.2.2(prettier@3.3.2)
+      proxy-agent:
+        specifier: ^8.0.1
+        version: 8.0.1
       typescript-eslint:
         specifier: ^8.42.0
         version: 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -2328,6 +2331,13 @@ packages:
     engines: { node: '>=0.4.0' }
     hasBin: true
 
+  agent-base@9.0.0:
+    resolution:
+      {
+        integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==,
+      }
+    engines: { node: '>= 20' }
+
   ajv-draft-04@1.0.0:
     resolution:
       {
@@ -2414,6 +2424,13 @@ packages:
         integrity: sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==,
       }
 
+  ast-types@0.13.4:
+    resolution:
+      {
+        integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==,
+      }
+    engines: { node: '>=4' }
+
   ast-walker-scope@0.8.3:
     resolution:
       {
@@ -2459,6 +2476,13 @@ packages:
       }
     engines: { node: '>=6.0.0' }
     hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution:
+      {
+        integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==,
+      }
+    engines: { node: '>=10.0.0' }
 
   binary-extensions@2.3.0:
     resolution:
@@ -2856,6 +2880,13 @@ packages:
         integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
       }
 
+  data-uri-to-buffer@8.0.0:
+    resolution:
+      {
+        integrity: sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==,
+      }
+    engines: { node: '>= 20' }
+
   date-fns-tz@3.2.0:
     resolution:
       {
@@ -2927,6 +2958,15 @@ packages:
       {
         integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
       }
+
+  degenerator@7.0.1:
+    resolution:
+      {
+        integrity: sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==,
+      }
+    engines: { node: '>= 20' }
+    peerDependencies:
+      quickjs-wasi: ^2.2.0
 
   depd@2.0.0:
     resolution:
@@ -3174,6 +3214,14 @@ packages:
       }
     engines: { node: '>=12' }
 
+  escodegen@2.1.0:
+    resolution:
+      {
+        integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==,
+      }
+    engines: { node: '>=6.0' }
+    hasBin: true
+
   eslint-config-prettier@10.1.8:
     resolution:
       {
@@ -3287,6 +3335,14 @@ packages:
         integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+  esprima@4.0.1:
+    resolution:
+      {
+        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
+      }
+    engines: { node: '>=4' }
+    hasBin: true
 
   esquery@1.7.0:
     resolution:
@@ -3519,6 +3575,13 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  get-uri@8.0.0:
+    resolution:
+      {
+        integrity: sha512-CqtZlMKvfJeY0Zxv8wazDwXmSKmnMnsmNy8j8+wudi8EyG/pMUB1NqHc+Tv1QaNtpYsK9nOYjb7r7Ufu32RPSw==,
+      }
+    engines: { node: '>= 20' }
+
   giget@3.2.0:
     resolution:
       {
@@ -3641,6 +3704,20 @@ packages:
         integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
       }
     engines: { node: '>= 0.8' }
+
+  http-proxy-agent@9.0.0:
+    resolution:
+      {
+        integrity: sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA==,
+      }
+    engines: { node: '>= 20' }
+
+  https-proxy-agent@9.0.0:
+    resolution:
+      {
+        integrity: sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==,
+      }
+    engines: { node: '>= 20' }
 
   husky@9.1.7:
     resolution:
@@ -3799,6 +3876,13 @@ packages:
       {
         integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
       }
+
+  ip-address@10.2.0:
+    resolution:
+      {
+        integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==,
+      }
+    engines: { node: '>= 12' }
 
   ipaddr.js@1.9.1:
     resolution:
@@ -4183,6 +4267,13 @@ packages:
         integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==,
       }
 
+  lru-cache@7.18.3:
+    resolution:
+      {
+        integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==,
+      }
+    engines: { node: '>=12' }
+
   magic-string-ast@1.0.3:
     resolution:
       {
@@ -4376,6 +4467,13 @@ packages:
       }
     engines: { node: '>= 0.6' }
 
+  netmask@2.1.1:
+    resolution:
+      {
+        integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==,
+      }
+    engines: { node: '>= 0.4.0' }
+
   no-case@3.0.4:
     resolution:
       {
@@ -4479,6 +4577,22 @@ packages:
         integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
       }
     engines: { node: '>=10' }
+
+  pac-proxy-agent@9.0.1:
+    resolution:
+      {
+        integrity: sha512-3ZOSpLboOlpW4yp8Cuv21KlTULRqyJ5Uuad3wXpSKFrxdNgcHEyoa22GRaZ2UlgCVuR6z+5BiavtYVvbajL/Yw==,
+      }
+    engines: { node: '>= 20' }
+
+  pac-resolver@9.0.1:
+    resolution:
+      {
+        integrity: sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==,
+      }
+    engines: { node: '>= 20' }
+    peerDependencies:
+      quickjs-wasi: ^2.2.0
 
   param-case@3.0.4:
     resolution:
@@ -4698,6 +4812,20 @@ packages:
       }
     engines: { node: '>= 0.10' }
 
+  proxy-agent@8.0.1:
+    resolution:
+      {
+        integrity: sha512-kccqGBqHZXR8onQhY/ganJjoO8QIKKRiFBhPOzbTZK16attzSZ/0XSmp9H7jrRxPKHjhGyx1q32lMPrJ3uLFgA==,
+      }
+    engines: { node: '>= 20' }
+
+  proxy-from-env@2.1.0:
+    resolution:
+      {
+        integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==,
+      }
+    engines: { node: '>=10' }
+
   punycode.js@2.3.1:
     resolution:
       {
@@ -4729,6 +4857,12 @@ packages:
     resolution:
       {
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+      }
+
+  quickjs-wasi@2.2.0:
+    resolution:
+      {
+        integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==,
       }
 
   range-parser@1.2.1:
@@ -4963,6 +5097,27 @@ packages:
       {
         integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
       }
+
+  smart-buffer@4.2.0:
+    resolution:
+      {
+        integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==,
+      }
+    engines: { node: '>= 6.0.0', npm: '>= 3.0.0' }
+
+  socks-proxy-agent@10.0.0:
+    resolution:
+      {
+        integrity: sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==,
+      }
+    engines: { node: '>= 20' }
+
+  socks@2.8.9:
+    resolution:
+      {
+        integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==,
+      }
+    engines: { node: '>= 10.0.0', npm: '>= 3.0.0' }
 
   sonda@0.7.1:
     resolution:
@@ -7050,6 +7205,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@9.0.0: {}
+
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -7104,6 +7261,10 @@ snapshots:
     dependencies:
       '@mdn/browser-compat-data': 5.7.6
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   ast-walker-scope@0.8.3:
     dependencies:
       '@babel/parser': 7.29.2
@@ -7122,6 +7283,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.0: {}
+
+  basic-ftp@5.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -7365,6 +7528,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@8.0.0: {}
+
   date-fns-tz@3.2.0(date-fns@4.1.0):
     dependencies:
       date-fns: 4.1.0
@@ -7392,6 +7557,13 @@ snapshots:
 
   defu@6.1.7:
     optional: true
+
+  degenerator@7.0.1(quickjs-wasi@2.2.0):
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+      quickjs-wasi: 2.2.0
 
   depd@2.0.0: {}
 
@@ -7531,6 +7703,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -7638,6 +7818,8 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
+
+  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -7800,6 +7982,14 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-uri@8.0.0:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 8.0.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   giget@3.2.0:
     optional: true
 
@@ -7861,6 +8051,20 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@9.0.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@9.0.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -7926,6 +8130,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -8106,6 +8312,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  lru-cache@7.18.3: {}
+
   magic-string-ast@1.0.3:
     dependencies:
       magic-string: 0.30.21
@@ -8222,6 +8430,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  netmask@2.1.1: {}
+
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -8284,6 +8494,25 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  pac-proxy-agent@9.0.1:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      get-uri: 8.0.0
+      http-proxy-agent: 9.0.0
+      https-proxy-agent: 9.0.0
+      pac-resolver: 9.0.1(quickjs-wasi@2.2.0)
+      quickjs-wasi: 2.2.0
+      socks-proxy-agent: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@9.0.1(quickjs-wasi@2.2.0):
+    dependencies:
+      degenerator: 7.0.1(quickjs-wasi@2.2.0)
+      netmask: 2.1.1
+      quickjs-wasi: 2.2.0
 
   param-case@3.0.4:
     dependencies:
@@ -8404,6 +8633,21 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@8.0.1:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      http-proxy-agent: 9.0.0
+      https-proxy-agent: 9.0.0
+      lru-cache: 7.18.3
+      pac-proxy-agent: 9.0.1
+      proxy-from-env: 2.1.0
+      socks-proxy-agent: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@2.1.0: {}
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
@@ -8415,6 +8659,8 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quickjs-wasi@2.2.0: {}
 
   range-parser@1.2.1: {}
 
@@ -8605,6 +8851,21 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@10.0.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
 
   sonda@0.7.1:
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "husky": "^9.1.7",
     "prettier": "3.3.2",
     "pretty-quick": "^4.2.2",
+    "proxy-agent": "^8.0.1",
     "typescript-eslint": "^8.42.0",
     "vitest": "^3.2.4"
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -185,14 +185,19 @@ export default defineConfig(({ mode }) => {
     setupRemoteAuthProxy(config);
   }
 
-  // 为 proxy 注入代理能力
-  const agent = new ProxyAgent();
+  // 注入代理能力以解决系统代理时的外网访问问题
+  // ProxyAgent 会自动使用系统代理设置，如果没有系统代理则直接连接目标服务器
+  const upstreamAgent = new ProxyAgent();
   const proxy = config.server!.proxy!;
-  Object.entries(proxy).forEach(([key, config]) => {
-    if (typeof config === 'object') {
-      config.agent = agent;
+  Object.entries(proxy).forEach(([key, proxyConfig]) => {
+    if (typeof proxyConfig === 'object') {
+      proxyConfig.agent = upstreamAgent;
     } else {
-      proxy[key] = { target: config, changeOrigin: true, agent };
+      proxy[key] = {
+        target: proxyConfig,
+        changeOrigin: true,
+        agent: upstreamAgent,
+      };
     }
   });
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,7 +6,7 @@ import Components from 'unplugin-vue-components/vite';
 import type { UserConfig } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
-
+import { ProxyAgent } from 'proxy-agent';
 import path from 'path';
 
 function setupRemoteAuthProxy(config: UserConfig) {
@@ -184,6 +184,17 @@ export default defineConfig(({ mode }) => {
   if (apiMode === 'remote') {
     setupRemoteAuthProxy(config);
   }
+
+  // 为 proxy 注入代理能力
+  const agent = new ProxyAgent();
+  const proxy = config.server!.proxy!;
+  Object.entries(proxy).forEach(([key, config]) => {
+    if (typeof config === 'object') {
+      config.agent = agent;
+    } else {
+      proxy[key] = { target: config, changeOrigin: true, agent };
+    }
+  });
 
   return config;
 });

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -217,14 +217,19 @@ export default defineConfig(({ mode }) => {
     setupRemoteAuthProxy(config);
   }
 
-  // 为 proxy 注入代理能力
-  const agent = new ProxyAgent();
+  // 注入代理能力以解决系统代理时的外网访问问题
+  // ProxyAgent 会自动使用系统代理设置，如果没有系统代理则直接连接目标服务器
+  const upstreamAgent = new ProxyAgent();
   const proxy = config.server!.proxy!;
-  Object.entries(proxy).forEach(([key, config]) => {
-    if (typeof config === 'object') {
-      config.agent = agent;
+  Object.entries(proxy).forEach(([key, proxyConfig]) => {
+    if (typeof proxyConfig === 'object') {
+      proxyConfig.agent = upstreamAgent;
     } else {
-      proxy[key] = { target: config, changeOrigin: true, agent };
+      proxy[key] = {
+        target: proxyConfig,
+        changeOrigin: true,
+        agent: upstreamAgent,
+      };
     }
   });
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,7 @@
 import vue from '@vitejs/plugin-vue';
+import { execFileSync } from 'node:child_process';
+import path from 'path';
+import { ProxyAgent } from 'proxy-agent';
 import Sonda from 'sonda/vite';
 import AutoImport from 'unplugin-auto-import/vite';
 import { NaiveUiResolver } from 'unplugin-vue-components/resolvers';
@@ -6,9 +9,6 @@ import Components from 'unplugin-vue-components/vite';
 import type { UserConfig } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
-
-import { execFileSync } from 'node:child_process';
-import path from 'path';
 
 function resolveGitCommit(env: Record<string, string>) {
   const injectedCommit =
@@ -216,6 +216,17 @@ export default defineConfig(({ mode }) => {
   if (apiMode === 'remote') {
     setupRemoteAuthProxy(config);
   }
+
+  // 为 proxy 注入代理能力
+  const agent = new ProxyAgent();
+  const proxy = config.server!.proxy!;
+  Object.entries(proxy).forEach(([key, config]) => {
+    if (typeof config === 'object') {
+      config.agent = agent;
+    } else {
+      proxy[key] = { target: config, changeOrigin: true, agent };
+    }
+  });
 
   return config;
 });


### PR DESCRIPTION
vite proxy 内部代理不会自动读取 env 里的 http_proxy 配置，导致部分环境下 remote 开发环境访问 novelia.cc 接口不通

ProxyAgent 内部会自动针对每个url判断是否需要设置代理，所以这里选择全部设置代理