### PR TITLE
fix(web): 修复pipeline工作区部分完成部分错误的任务无法删除的问题

### DIFF
--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -196,11 +196,14 @@ function runProcessLoop(): Promise<void> | null {
           signal,
         )
         .then(() => {
+          const allDone = state.chapters.every((c) => c.status === 'done');
           const allProcessed = state.chapters.every(
             (c) => c.status === 'done' || c.status === 'error',
           );
           if (allProcessed) {
             executingTasks.delete(job.task);
+          }
+          if (allDone) {
             (job as TranslateJobRecord).finishAt = Date.now();
           }
         });

--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -196,8 +196,10 @@ function runProcessLoop(): Promise<void> | null {
           signal,
         )
         .then(() => {
-          const allDone = state.chapters.every((c) => c.status === 'done');
-          if (allDone) {
+          const allProcessed = state.chapters.every(
+            (c) => c.status === 'done' || c.status === 'error',
+          );
+          if (allProcessed) {
             executingTasks.delete(job.task);
             (job as TranslateJobRecord).finishAt = Date.now();
           }


### PR DESCRIPTION
修复 #396 中提到的一个问题：“小部分已翻译完成的小说任务会变成等待中的状态。无法对翻译完成但变成等待中的任务进行删除操作，切换状态标签也不会刷新状态，得刷新页面才变为已完成状态”。

这是由于之前只有全部章节已完成的任务才会从“当前执行的任务”中移除，导致翻译循环正在进行时无法删除任务。目前任务中仅包含“已完成”和“错误”章节时可以正常删除了。