### PR TITLE
fix(server): 修复收藏夹列表 BSON 超过 16MB 导致 500

### DIFF
--- a/server/src/main/kotlin/infra/web/repository/WebNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelFavoredRepository.kt
@@ -17,10 +17,13 @@ import infra.web.WebNovel
 import infra.web.WebNovelAttention
 import infra.web.WebNovelListItem
 import infra.web.WebNovelFilter
+import infra.web.WebNovelTocItem
 import infra.web.WebNovelType
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.bson.types.ObjectId
 import org.bson.conversions.Bson
@@ -64,8 +67,8 @@ class WebNovelFavoredRepository(
     ): Page<WebNovelListItem> {
         @Serializable
         data class NovelWithContext(
-            val novel: WebNovel,
-            val favoredId: String, // 小说所属的收藏夹ID
+            val novel: FavoredNovelLookup,
+            val favoredId: String,
         )
         @Serializable
         data class PageModel(
@@ -105,7 +108,7 @@ class WebNovelFavoredRepository(
                                 operator,
                                 BsonArray(
                                     listOf(
-                                        BsonDocument("\$size", BsonString("\$novel.toc")), // 获取 toc 数组的长度
+                                        BsonDocument("\$size", BsonString("\$novel.toc")),
                                         BsonInt32(number)
                                     )
                                 )
@@ -177,12 +180,7 @@ class WebNovelFavoredRepository(
             .aggregate<PageModel>(
                 match(initialFilter),
                 sort(sortBson),
-                lookup(
-                    /* from = */ MongoCollectionNames.WEB_NOVEL,
-                    /* localField = */ WebNovelFavoriteDbModel::novelId.field(),
-                    /* foreignField = */ WebNovel::id.field(),
-                    /* as = */ "novel"
-                ),
+                favoredNovelLookup(),
                 unwind("\$novel"),
                 project(
                     fields(
@@ -214,14 +212,11 @@ class WebNovelFavoredRepository(
             Page(
                 items = doc.items.map { novelWithContext ->
                     val favored = if (favoredId == null) {
-                        // favoredId为null时的模式为查询所有收藏夹，这时把查询小说的收藏夹发送回去
                         novelWithContext.favoredId
                     } else {
                         null
                     }
-                    novelWithContext.novel.toOutline(
-                        favored = favored
-                    )
+                    novelWithContext.novel.toOutline(favored = favored)
                 },
                 total = doc.total.toLong(),
                 pageSize = pageSize,
@@ -278,3 +273,93 @@ class WebNovelFavoredRepository(
             )
     }
 }
+
+@Serializable
+internal data class FavoredNovelTocLookup(
+    @SerialName("episodeId") val chapterId: String? = null,
+)
+
+@Serializable
+internal data class FavoredNovelLookup(
+    val providerId: String,
+    @SerialName("bookId") val novelId: String,
+    val titleJp: String,
+    val titleZh: String? = null,
+    val type: WebNovelType? = null,
+    val attentions: List<WebNovelAttention> = emptyList(),
+    val keywords: List<String> = emptyList(),
+    val toc: List<FavoredNovelTocLookup> = emptyList(),
+    val jp: Long = 0,
+    val baidu: Long = 0,
+    val youdao: Long = 0,
+    val gpt: Long = 0,
+    val sakura: Long = 0,
+    @Contextual val updateAt: Instant? = null,
+) {
+    fun toOutline(favored: String? = null) =
+        WebNovelListItem(
+            providerId = providerId,
+            novelId = novelId,
+            titleJp = titleJp,
+            titleZh = titleZh,
+            type = type,
+            attentions = attentions,
+            keywords = keywords,
+            favored = favored,
+            total = toc.count { it.chapterId != null }.toLong(),
+            jp = jp,
+            baidu = baidu,
+            youdao = youdao,
+            gpt = gpt,
+            sakura = sakura,
+            updateAt = updateAt,
+        )
+}
+
+private fun favoredNovelLookup(): Bson =
+    lookup(
+        MongoCollectionNames.WEB_NOVEL,
+        WebNovelFavoriteDbModel::novelId.field(),
+        WebNovel::id.field(),
+        favoredNovelLookupProjectionPipeline(),
+        "novel",
+    )
+
+private fun favoredNovelLookupProjectionPipeline(): List<Bson> =
+    listOf(
+        project(
+            fields(
+                include(
+                    WebNovel::providerId.field(),
+                    WebNovel::novelId.field(),
+                    WebNovel::titleJp.field(),
+                    WebNovel::titleZh.field(),
+                    WebNovel::type.field(),
+                    WebNovel::attentions.field(),
+                    WebNovel::keywords.field(),
+                    WebNovel::jp.field(),
+                    WebNovel::baidu.field(),
+                    WebNovel::youdao.field(),
+                    WebNovel::gpt.field(),
+                    WebNovel::sakura.field(),
+                    WebNovel::updateAt.field(),
+                ),
+                computed(
+                    WebNovel::toc.field(),
+                    BsonDocument(
+                        "\$map",
+                        BsonDocument()
+                            .append("input", BsonString("\$${WebNovel::toc.field()}"))
+                            .append("as", BsonString("item"))
+                            .append(
+                                "in",
+                                BsonDocument(
+                                    WebNovelTocItem::chapterId.field(),
+                                    BsonString("\$\$item.${WebNovelTocItem::chapterId.field()}"),
+                                ),
+                            ),
+                    ),
+                ),
+            ),
+        ),
+    )

--- a/server/src/main/kotlin/infra/web/repository/WebNovelFavoredRepository.kt
+++ b/server/src/main/kotlin/infra/web/repository/WebNovelFavoredRepository.kt
@@ -31,6 +31,7 @@ import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString
+import org.bson.Document
 
 class WebNovelFavoredRepository(
     mongo: MongoClient,
@@ -317,12 +318,16 @@ internal data class FavoredNovelLookup(
 }
 
 private fun favoredNovelLookup(): Bson =
-    lookup(
-        MongoCollectionNames.WEB_NOVEL,
-        WebNovelFavoriteDbModel::novelId.field(),
-        WebNovel::id.field(),
-        favoredNovelLookupProjectionPipeline(),
-        "novel",
+    // Aggregates.lookup 没有 (from, localField, foreignField, pipeline, as) 重载，
+    // 用 Document 构造 MongoDB 5.0+ 支持的 localField + pipeline 形态。
+    Document(
+        "\$lookup",
+        Document()
+            .append("from", MongoCollectionNames.WEB_NOVEL)
+            .append("localField", WebNovelFavoriteDbModel::novelId.field())
+            .append("foreignField", WebNovel::id.field())
+            .append("pipeline", favoredNovelLookupProjectionPipeline())
+            .append("as", "novel"),
     )
 
 private fun favoredNovelLookupProjectionPipeline(): List<Bson> =

--- a/server/src/test/kotlin/infra/web/repository/WebNovelFavoredRepositoryTest.kt
+++ b/server/src/test/kotlin/infra/web/repository/WebNovelFavoredRepositoryTest.kt
@@ -1,0 +1,62 @@
+package infra.web.repository
+
+import infra.web.WebNovelAttention
+import infra.web.WebNovelType
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.Instant
+
+class WebNovelFavoredRepositoryTest : DescribeSpec({
+    describe("FavoredNovelLookup.toOutline") {
+        it("只根据 chapterId 统计章节数，忽略 null 条目") {
+            val novel = FavoredNovelLookup(
+                providerId = "syosetu",
+                novelId = "n1234",
+                titleJp = "テスト",
+                titleZh = "测试",
+                type = WebNovelType.连载中,
+                attentions = listOf(WebNovelAttention.R18),
+                keywords = listOf("奇幻"),
+                toc = listOf(
+                    FavoredNovelTocLookup(chapterId = "1"),
+                    FavoredNovelTocLookup(chapterId = null),
+                    FavoredNovelTocLookup(chapterId = "2"),
+                ),
+                jp = 1,
+                baidu = 2,
+                youdao = 3,
+                gpt = 4,
+                sakura = 5,
+                updateAt = Instant.fromEpochSeconds(1_700_000_000),
+            )
+
+            val outline = novel.toOutline(favored = "default")
+
+            outline.providerId shouldBe "syosetu"
+            outline.novelId shouldBe "n1234"
+            outline.titleJp shouldBe "テスト"
+            outline.titleZh shouldBe "测试"
+            outline.type shouldBe WebNovelType.连载中
+            outline.attentions shouldBe listOf(WebNovelAttention.R18)
+            outline.keywords shouldBe listOf("奇幻")
+            outline.favored shouldBe "default"
+            outline.total shouldBe 2
+            outline.jp shouldBe 1
+            outline.baidu shouldBe 2
+            outline.youdao shouldBe 3
+            outline.gpt shouldBe 4
+            outline.sakura shouldBe 5
+            outline.updateAt shouldBe Instant.fromEpochSeconds(1_700_000_000)
+        }
+
+        it("favored 为 null 时不写入收藏夹信息") {
+            val novel = FavoredNovelLookup(
+                providerId = "kakuyomu",
+                novelId = "works/1",
+                titleJp = "作品",
+            )
+
+            novel.toOutline(favored = null).favored shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
## Summary

修复自建收藏夹页面 `/api/user/favored-web/{id}` 在收藏量较大时返回 500 的问题（#361）。

根因：`listFavoredNovel` 聚合通过 `$lookup` 拉取完整 `WebNovel` 文档（含 glossary、简介、完整 toc 等），`$facet` 输出的一页结果 BSON 体积超过 MongoDB 16MB 上限，触发 `BSONObjectTooLarge (10334)`。

修复：`$lookup` 增加 pipeline projection，仅保留列表页所需字段；`toc` 只投影 `chapterId` 用于章节数统计与 `>N` 筛选，排除 glossary/简介等大字段。

## Test plan

- [ ] `./gradlew test --tests "infra.web.repository.WebNovelFavoredRepositoryTest"` 通过
- [ ] 问题用户收藏夹 `568e97b7-a8d7-47ac-98e1-e5190a537f70` 首页请求返回 200（原报错 URL）
- [ ] 翻页、搜索、标签筛选、`>N` 章节数筛选、排序功能正常
- [ ] 大收藏夹（数百本以上）稳定不再 500

Fixes #361


Made with [Cursor](https://cursor.com)