### PR TITLE
feat(web): 编辑术语表新增按鈕-從剪貼簿導入術語表textarea

### DIFF
--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -8,6 +8,8 @@ import {
   FileDownloadOutlined,
 } from '@vicons/material';
 
+import { isEqual } from 'lodash-es';
+
 import { WebNovelApi, WenkuNovelApi } from '@/api';
 import { GenericNovelId } from '@/model/Common';
 import { Glossary } from '@/model/Glossary';
@@ -32,8 +34,50 @@ const showGlossaryModal = ref(false);
 const toggleGlossaryModal = () => {
   if (showGlossaryModal.value === false) {
     glossary.value = { ...props.value };
+    showGlossaryModal.value = true;
+  } else {
+    handleUpdateShow(false);
   }
-  showGlossaryModal.value = !showGlossaryModal.value;
+};
+
+const handleUpdateShow = async (value: boolean) => {
+  if (value === false) {
+    const hasChanges = !isEqual(toRaw(glossary.value), toRaw(props.value));
+    if (hasChanges) {
+      if (window.confirm('术语表有未保存的修改，是否保存？')) {
+        await handleSaveConfirm();
+      } else {
+        if (window.confirm('是否确认不保存并关闭？')) {
+          handleDiscardConfirm();
+        }
+      }
+    } else {
+      showGlossaryModal.value = false;
+    }
+  } else {
+    showGlossaryModal.value = true;
+  }
+};
+
+const handleSaveConfirm = async () => {
+  try {
+    await updateGlossary();
+    for (const key in props.value) {
+      delete props.value[key];
+    }
+    for (const key in glossary.value) {
+      props.value[key] = glossary.value[key];
+    }
+    message.success('保存成功');
+    showGlossaryModal.value = false;
+  } catch (e: any) {
+    message.error('保存失败:' + e);
+  }
+};
+
+const handleDiscardConfirm = () => {
+  glossary.value = { ...props.value };
+  showGlossaryModal.value = false;
 };
 
 const gnidHint = computed(() => {
@@ -187,7 +231,8 @@ const importGlossaryFromClipboard = async () => {
 
   <c-modal
     title="编辑术语表"
-    v-model:show="showGlossaryModal"
+    :show="showGlossaryModal"
+    @update:show="handleUpdateShow"
     :extra-height="120"
   >
     <template #header-extra>

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -1,5 +1,12 @@
 <script lang="ts" setup>
-import { DeleteOutlineOutlined } from '@vicons/material';
+import {
+  DeleteOutlineOutlined,
+  ContentCopyOutlined,
+  UploadOutlined,
+  DownloadOutlined,
+  ContentPasteOutlined,
+  FileDownloadOutlined,
+} from '@vicons/material';
 
 import { WebNovelApi, WenkuNovelApi } from '@/api';
 import { GenericNovelId } from '@/model/Common';
@@ -151,6 +158,7 @@ const importGlossaryFromClipboard = async () => {
       JSON.parse(text);
       isValid = true;
     } catch {
+      // If not JSON, check if it's the valid human-readable glossary format
       const imported = Glossary.fromText(text);
       if (imported !== undefined) {
         isValid = true;
@@ -158,7 +166,7 @@ const importGlossaryFromClipboard = async () => {
     }
 
     if (!isValid) {
-      message.error('检测到内容不是支援格式');
+      message.error('检测到剪贴簿内容不是 JSON 格式');
       return;
     }
 
@@ -224,41 +232,55 @@ const importGlossaryFromClipboard = async () => {
           :rows="1"
         />
 
-        <n-flex align="center" :wrap="false">
-          <c-button
-            label="导出"
-            :round="false"
-            size="small"
-            @action="exportGlossary"
-          />
-          <c-button
-            label="剪贴簿导入"
-            :round="false"
-            size="small"
-            @action="importGlossaryFromClipboard"
-          />
-          <c-button
-            label="导入"
-            :round="false"
-            size="small"
-            @action="importGlossary"
-          />
-          <c-button
-            label="下载json"
-            :round="false"
-            size="small"
-            @action="downloadGlossaryAsJsonFile"
-          />
-          <c-button
-            v-if="whoami.isAdmin"
-            secondary
-            type="error"
-            label="清空"
-            :round="false"
-            size="small"
-            @action="clearTerm"
-          />
-        </n-flex>
+        <c-action-wrapper align="center" title="编辑区">
+          <n-flex align="center" :wrap="false">
+            <c-button
+              label="导入"
+              :icon="DownloadOutlined"
+              :round="false"
+              size="small"
+              @action="importGlossary"
+            />
+            <c-button
+              label="下载JSON"
+              :icon="FileDownloadOutlined"
+              :round="false"
+              size="small"
+              @action="downloadGlossaryAsJsonFile"
+            />
+            <c-button
+              v-if="whoami.isAdmin"
+              secondary
+              type="error"
+              label="清空"
+              :icon="DeleteOutlineOutlined"
+              :round="false"
+              size="small"
+              @action="clearTerm"
+            />
+          </n-flex>
+        </c-action-wrapper>
+
+        <c-action-wrapper align="center" title="剪贴簿">
+          <n-flex align="center" :wrap="false">
+            <c-button
+              label="导出"
+              :icon="ContentCopyOutlined"
+              :round="false"
+              size="small"
+              @action="exportGlossary"
+            />
+            <c-button
+              class="clipboard-import-btn"
+              label="剪贴"
+              :icon="ContentPasteOutlined"
+              :round="false"
+              size="small"
+              @action="importGlossaryFromClipboard"
+            />
+          </n-flex>
+        </c-action-wrapper>
+
         <n-flex align="center" :wrap="false">
           <c-button
             :disabled="deletedTerms.length === 0"

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -160,10 +160,10 @@ const addTerm = () => {
   }
 };
 
-const exportGlossary = async (ev: MouseEvent) => {
+const exportGlossary = async (ev?: MouseEvent) => {
   const isSuccess = await copyToClipBoard(
     Glossary.toText(glossary.value),
-    ev.target as HTMLElement,
+    ev?.target as HTMLElement,
   );
   if (isSuccess) {
     message.success('导出成功：已复制到剪贴板');
@@ -220,6 +220,49 @@ const importGlossaryFromClipboard = async () => {
     message.error('无法读取剪贴簿: ' + (err?.message ?? err));
   }
 };
+
+const isEditable = (el: Element | null): boolean => {
+  if (!el) return false;
+  const tagName = el.tagName.toUpperCase();
+  if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+    return true;
+  }
+  if (
+    el.hasAttribute('contenteditable') &&
+    el.getAttribute('contenteditable') !== 'false'
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const handleKeyDown = (e: KeyboardEvent) => {
+  if (isEditable(document.activeElement)) {
+    return;
+  }
+  const isCtrlOrCmd = e.ctrlKey || e.metaKey;
+  if (isCtrlOrCmd) {
+    if (e.key === 'c' || e.key === 'C') {
+      e.preventDefault();
+      exportGlossary();
+    } else if (e.key === 'v' || e.key === 'V') {
+      e.preventDefault();
+      importGlossaryFromClipboard();
+    }
+  }
+};
+
+watch(showGlossaryModal, (isOpen) => {
+  if (isOpen) {
+    window.addEventListener('keydown', handleKeyDown);
+  } else {
+    window.removeEventListener('keydown', handleKeyDown);
+  }
+});
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeyDown);
+});
 </script>
 
 <template>

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -142,6 +142,32 @@ const downloadGlossaryAsJsonFile = async (ev: MouseEvent) => {
     }),
   );
 };
+
+const importGlossaryFromClipboard = async () => {
+  try {
+    const text = await navigator.clipboard.readText();
+    let isValid = false;
+    try {
+      JSON.parse(text);
+      isValid = true;
+    } catch {
+      const imported = Glossary.fromText(text);
+      if (imported !== undefined) {
+        isValid = true;
+      }
+    }
+
+    if (!isValid) {
+      message.error('检测到内容不是支援格式');
+      return;
+    }
+
+    importGlossaryRaw.value = text;
+    message.success('从剪贴簿导入成功');
+  } catch (err: any) {
+    message.error('无法读取剪贴簿: ' + (err?.message ?? err));
+  }
+};
 </script>
 
 <template>
@@ -206,13 +232,19 @@ const downloadGlossaryAsJsonFile = async (ev: MouseEvent) => {
             @action="exportGlossary"
           />
           <c-button
+            label="剪贴簿导入"
+            :round="false"
+            size="small"
+            @action="importGlossaryFromClipboard"
+          />
+          <c-button
             label="导入"
             :round="false"
             size="small"
             @action="importGlossary"
           />
           <c-button
-            label="下载json文件"
+            label="下载json"
             :round="false"
             size="small"
             @action="downloadGlossaryAsJsonFile"

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -240,6 +240,10 @@ const handleKeyDown = (e: KeyboardEvent) => {
   if (isEditable(document.activeElement)) {
     return;
   }
+  // 如果选取了文本（例如，在表格中选取的文字），不触发全局的复制（Ctrl+C/V）快捷键
+  if (window.getSelection()?.toString()) {
+    return;
+  }
   const isCtrlOrCmd = e.ctrlKey || e.metaKey;
   if (isCtrlOrCmd) {
     if (e.key === 'c' || e.key === 'C') {

--- a/web/src/components/GlossaryButton.vue
+++ b/web/src/components/GlossaryButton.vue
@@ -47,9 +47,7 @@ const handleUpdateShow = async (value: boolean) => {
       if (window.confirm('术语表有未保存的修改，是否保存？')) {
         await handleSaveConfirm();
       } else {
-        if (window.confirm('是否确认不保存并关闭？')) {
-          handleDiscardConfirm();
-        }
+        handleDiscardConfirm();
       }
     } else {
       showGlossaryModal.value = false;


### PR DESCRIPTION
- 新增按鈕: 從剪貼簿導入"批量導入區"，支援 [jp => zh] 或 JSON格式
- Ctrl+C / V 可以觸發 "導出(編輯區->clipboard)" / "導入(剪貼簿->批量導入區)" 功能
- 添加術語表 modal 關閉 js confirm (如果有更改)

當前有：術語表->剪貼簿、textarea->術語表 的按鈕，卻沒有 剪貼簿->TextArea
優化操作手感，對於手機可以省略按住選取textarea再貼上的操作


<img width="569" height="430" alt="image" src="https://github.com/user-attachments/assets/b7e98a33-5e40-47eb-91a3-dbcde5c9bf9b" />

<img width="756" height="913" alt="image" src="https://github.com/user-attachments/assets/0092bc87-abad-4563-9f6a-38e1ce53558e" />