### PR TITLE
fix: 修正更新目录逻辑

### DIFF
--- a/web/src/domain/crawler/TocUpdate.ts
+++ b/web/src/domain/crawler/TocUpdate.ts
@@ -1,0 +1,54 @@
+export type CrawlerTocItem = Readonly<{
+  title: string;
+  chapterId: string | null;
+  createAt: string | null;
+}>;
+
+export type TocUpdateKind = 'unchanged' | 'append-only' | 'existing-updated';
+
+const isSameTocItem = (left: CrawlerTocItem, right: CrawlerTocItem) =>
+  left.title === right.title &&
+  left.chapterId === right.chapterId &&
+  left.createAt === right.createAt;
+
+export const classifyTocUpdate = (
+  currentToc: readonly CrawlerTocItem[],
+  newToc: readonly CrawlerTocItem[],
+): TocUpdateKind => {
+  const currentChapterIds = new Set(
+    currentToc.flatMap((item) =>
+      item.chapterId == null ? [] : [item.chapterId],
+    ),
+  );
+  const currentChapterItems = currentToc.filter(
+    (item) => item.chapterId != null,
+  );
+  const newExistingChapterItems = newToc.filter(
+    (item) => item.chapterId != null && currentChapterIds.has(item.chapterId),
+  );
+
+  if (
+    currentChapterItems.length !== newExistingChapterItems.length ||
+    currentChapterItems.some(
+      (item, index) => !isSameTocItem(item, newExistingChapterItems[index]!),
+    )
+  ) {
+    return 'existing-updated';
+  }
+
+  let currentIndex = 0;
+  for (const newItem of newToc) {
+    const currentItem = currentToc[currentIndex];
+    if (currentItem != null && isSameTocItem(currentItem, newItem)) {
+      currentIndex += 1;
+    }
+  }
+  if (currentIndex !== currentToc.length) {
+    return 'existing-updated';
+  }
+
+  const hasNewChapter = newToc.some(
+    (item) => item.chapterId != null && !currentChapterIds.has(item.chapterId),
+  );
+  return hasNewChapter ? 'append-only' : 'unchanged';
+};

--- a/web/src/domain/crawler/index.ts
+++ b/web/src/domain/crawler/index.ts
@@ -6,6 +6,8 @@ import { WebNovelCrawlerApi } from '@/external';
 import type { WebNovelDto } from '@/model/WebNovel';
 import { WebNovelRepo } from '@/repos';
 
+import { classifyTocUpdate } from './TocUpdate';
+
 const toMutationBody = (metadata: WebNovelMetadata) => ({
   title: metadata.title,
   authors: metadata.authors.map((author) => ({
@@ -51,15 +53,37 @@ const updateWebNovel = async (
   providerId: string,
   novelId: string,
   current?: WebNovelDto,
+  options?: { safeUpdateToc?: boolean },
 ) => {
+  const safeUpdateToc = options?.safeUpdateToc ?? true;
   const metadata = await WebNovelCrawlerApi.getMetadata(providerId, novelId);
   const body = toMutationBody(metadata);
   current ??= await WebNovelApi.getNovel(providerId, novelId);
+  const currentBody = toCurrentMutationBody(current);
+
+  const newChapterIds = body.toc.flatMap((item) =>
+    item.chapterId == null ? [] : [item.chapterId],
+  );
+
+  if (newChapterIds.length === 0) {
+    throw new Error('未获取到目录，请手动打开源站确保你有办法访问');
+  }
   if (body.toc.length < current.toc.length) {
     throw new Error('目录变短，放弃更新，请手动打开源站确保你有办法访问');
   }
-  if (isEqual(body, toCurrentMutationBody(current))) {
+
+  if (isEqual(body, currentBody)) {
     throw new Error('没有必要更新');
+  }
+
+  if (safeUpdateToc) {
+    const tocUpdateKind = classifyTocUpdate(currentBody.toc, body.toc);
+    if (tocUpdateKind === 'existing-updated') {
+      throw new Error('已有目录发生变化，非源站同步模式仅允许新增章节');
+    }
+    if (tocUpdateKind === 'unchanged') {
+      throw new Error('没有新增章节，放弃更新');
+    }
   }
 
   await WebNovelRepo.updateNovel(providerId, novelId, body);

--- a/web/src/domain/translate/TranslateWeb.ts
+++ b/web/src/domain/translate/TranslateWeb.ts
@@ -27,15 +27,11 @@ export const translateWeb = async (
     try {
       callback.log('获取小说信息');
       const novel = await WebNovelApi.getNovel(providerId, novelId);
-      const sinceLastSyncMs = Date.now() - novel.syncAt * 1000;
-      const SYNC_EXPIRY_MS = 60 * 60 * 1000;
-      if (sinceLastSyncMs > SYNC_EXPIRY_MS) {
-        callback.log('通过浏览器爬虫更新目录');
-        await CrawlerService.updateWebNovel(providerId, novelId, novel);
-        callback.log('目录已更新');
-      } else {
-        callback.log(`syncAt 未过期，跳过目录更新`);
-      }
+      callback.log('通过浏览器爬虫更新目录');
+      await CrawlerService.updateWebNovel(providerId, novelId, novel, {
+        safeUpdateToc: level !== 'sync',
+      });
+      callback.log('目录已更新');
     } catch (e) {
       if (e instanceof DOMException && e.name === 'AbortError') {
         callback.log(`中止翻译任务`);

--- a/web/tests/tocUpdate.test.ts
+++ b/web/tests/tocUpdate.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyTocUpdate,
+  type CrawlerTocItem,
+} from '../src/domain/crawler/TocUpdate';
+
+const chapter = (
+  chapterId: string,
+  title = chapterId,
+  createAt: string | null = null,
+): CrawlerTocItem => ({ title, chapterId, createAt });
+
+const section = (title: string): CrawlerTocItem => ({
+  title,
+  chapterId: null,
+  createAt: null,
+});
+
+describe('classifyTocUpdate', () => {
+  const current = [section('第一卷'), chapter('1'), chapter('2')];
+
+  it('allows new chapters appended to the end', () => {
+    expect(classifyTocUpdate(current, [...current, chapter('3')])).toBe(
+      'append-only',
+    );
+  });
+
+  it('allows new chapters inserted without changing existing items', () => {
+    expect(
+      classifyTocUpdate(current, [
+        section('第一卷'),
+        chapter('1'),
+        chapter('1.5'),
+        chapter('2'),
+      ]),
+    ).toBe('append-only');
+  });
+
+  it('rejects an existing chapter update', () => {
+    expect(
+      classifyTocUpdate(current, [
+        section('第一卷'),
+        chapter('1', '修改后的标题'),
+        chapter('2'),
+      ]),
+    ).toBe('existing-updated');
+  });
+
+  it('rejects an existing chapter update even when a chapter was added', () => {
+    expect(
+      classifyTocUpdate(current, [
+        section('第一卷'),
+        chapter('1', '修改后的标题'),
+        chapter('2'),
+        chapter('3'),
+      ]),
+    ).toBe('existing-updated');
+  });
+
+  it('rejects replacing an existing chapter with a new chapter', () => {
+    expect(
+      classifyTocUpdate(current, [
+        section('第一卷'),
+        chapter('1'),
+        chapter('3'),
+      ]),
+    ).toBe('existing-updated');
+  });
+
+  it('rejects existing item reordering', () => {
+    expect(
+      classifyTocUpdate(current, [
+        section('第一卷'),
+        chapter('2'),
+        chapter('1'),
+      ]),
+    ).toBe('existing-updated');
+  });
+
+  it('rejects an existing section update', () => {
+    expect(
+      classifyTocUpdate(current, [
+        section('修改后的卷名'),
+        chapter('1'),
+        chapter('2'),
+        chapter('3'),
+      ]),
+    ).toBe('existing-updated');
+  });
+
+  it('reports an unchanged toc when no chapter was added', () => {
+    expect(classifyTocUpdate(current, current)).toBe('unchanged');
+  });
+});


### PR DESCRIPTION
* 源站同步：允许用户重试提交目录更新
* 非源站同步：仅允许 append-only 的目录更新
* 用户使用浏览器爬虫更新目录不再受 syncAt 限制
* 严格限制空目录提交

Co-Authored-by: codex