### PR TITLE
fix(web): 修复手机端目录滑动的跳动与双滚动条

### DIFF
--- a/web/src/components/ChapterTocList.vue
+++ b/web/src/components/ChapterTocList.vue
@@ -99,6 +99,7 @@ const noSeparatorClass = computed(() => {
     style="overflow: auto"
     :class="noSeparatorClass"
     :scrollbar-props="{ trigger: 'none' }"
+    item-resizable
   >
     <template #default="{ item: chapter }">
       <div :key="chapter.chapterId">

--- a/web/src/pages/reader/components/CatalogModal.vue
+++ b/web/src/pages/reader/components/CatalogModal.vue
@@ -123,6 +123,8 @@ const onTocItemClick = (item: ReadableTocItem) => {
   <c-modal
     :show="show"
     @update:show="$emit('update:show', $event)"
+    :max-height-percentage="80"
+    :extra-height="200"
     style="min-height: 30vh; max-height: 80vh"
     content-style="overflow: auto;"
   >


### PR DESCRIPTION
手机端目录的两个滚动问题，分别修复：

**一、滑动目录时画面会突跳**

- 无分卷的章节列表使用固定 `item-size="75.2"` 渲染，但标题换行的条目实际高度会超出该值（实测 75.2 / 97.6 / 120）
- 虚拟列表按 `translateY(startIndex × 75.2)` 定位，每越过一个较高条目的边界就突跳一次“实际高度 - item-size”的距离（实测 44.8px）
- 手指滑动是 1:1 跟手，该错位尤其明显；鼠标滚轮本身就是离散跳跃，不易察觉
- 补上 `item-resizable`，与该文件中另外两处（有分卷的分支）的用法保持一致

**二、阅读页面的目录弹窗出现两条滚动条**

- `CModal` 内层 n-scrollbar 限高为 `60% × innerHeight`，而目录列表自身限高为 `calc(80dvh - 200px)`，两者在窗口高度 1000px 处交叉
- 超过 1000px 后目录列表比外层容器更高，把外层撑出可滚动量，于是多出第二条滚动条；因此只在屏幕较高的设备上复现，较矮的屏幕看不到
- 让 `CModal` 采用与目录列表相同的公式，外层不再被撑开

验证：手机 UA + 触摸模拟下，窗口高度 850 / 1050 / 1200 / 1400 / 1800 均只剩一条滚动条；连续滚动 3000px 无跳动；宽屏模式与抽屉模式未受影响。