### PR TITLE
fix(web): 修复手机端目录弹窗仍出现双滚动条问题

### DIFF
--- a/web/src/components/CModal.vue
+++ b/web/src/components/CModal.vue
@@ -1,7 +1,12 @@
 <script lang="ts" setup>
 import { useWindowSize } from '@vueuse/core';
 
-defineProps<{ maxHeightPercentage?: number; extraHeight?: number }>();
+defineProps<{
+  maxHeightPercentage?: number;
+  extraHeight?: number;
+  // 内容自身已是滚动容器时开启，跳过外层滚动条，避免嵌套出现两条滚动条
+  contentScrollable?: boolean;
+}>();
 
 const { height } = useWindowSize();
 </script>
@@ -22,7 +27,11 @@ const { height } = useWindowSize();
     </template>
     <slot name="header-extra" />
 
+    <div v-if="contentScrollable" style="padding-right: 16px">
+      <slot />
+    </div>
     <n-scrollbar
+      v-else
       trigger="none"
       :style="{
         'max-height': `${((maxHeightPercentage ?? 60) / 100) * height - (extraHeight ?? 0)}px`,

--- a/web/src/pages/reader/components/CatalogModal.vue
+++ b/web/src/pages/reader/components/CatalogModal.vue
@@ -123,8 +123,7 @@ const onTocItemClick = (item: ReadableTocItem) => {
   <c-modal
     :show="show"
     @update:show="$emit('update:show', $event)"
-    :max-height-percentage="80"
-    :extra-height="200"
+    content-scrollable
     style="min-height: 30vh; max-height: 80vh"
     content-style="overflow: auto;"
   >


### PR DESCRIPTION
#421 让 CModal 与目录列表采用相同的限高公式，但两者的高度来源不同，真机上仍会出现两条滚动条。

**为什么没修干净**

| | 来源 | 真机上的值 |
|---|---|---|
| CModal 内层 | JS `window.innerHeight` | 818（取整） |
| `.modal-virtual-list` | CSS `100dvh` | 818.2857 |

该机 CSS 视窗高为 2148 设备像素 ÷ 2.625 DPR = 818.2857，`window.innerHeight` 取整为 818。乘 0.8 后两个公式相差 0.225px，布局后变成 1px 溢出，外层又被撑出滚动条（实测 `n-scrollbar-container` 的 `over = 1`）。桌面 DPR 为整数，两者完全相等，所以只在真机上复现。

**改法**

不再让两个数值互相迁就，而是消除嵌套：目录本身就是滚动容器，外层不需要再包一层滚动条。

- `CModal` 新增 `contentScrollable`，开启时跳过外层 n-scrollbar
- `CatalogModal` 改用它，并移除不再需要的 `maxHeightPercentage` / `extraHeight`

这样不再依赖任何高度数值。

**验证**

- 真机（Android Chrome，DPR 2.625，innerHeight 818）：仅剩 1 条滚动条，可滚动祖先只有 `.v-vl`，滚动跳动 0
- 模拟器窗口高 500 / 700 / 900 / 1200：均只剩 1 条，卡片未超出 max-height
- 默认路径回归（矮窗口强制设置弹窗内容溢出）：外层滚动条仍在且可滚动，1 条
- 目录加载失败时的 `c-result` 错误态：无溢出、无滚动条