### PR TITLE
fix(server+crawler): kakuyomu rankings

### DIFF
--- a/packages/crawler/src/web/kakuyomu.ts
+++ b/packages/crawler/src/web/kakuyomu.ts
@@ -100,13 +100,13 @@ export class Kakuyomu implements WebNovelProvider<GetRankOptions> {
       `https://kakuyomu.jp/rankings/${genreId}/${rangeId}?work_variation=${statusId}`,
     );
 
-    const items = $('div.widget-media-genresWorkList-right > div.widget-work')
+    const items = $('li[class*="Rankings_item__"]')
       .map((_, item) => {
         const root = $(item);
-        const titleLink = root.find('a.bookWalker-work-title').first();
+        const titleLink = root.find('h3 a[href^="/works/"]').first();
 
         const attentions: WebNovelAttention[] = [];
-        root.find('b.widget-workCard-flags > span').each((_, tagEl) => {
+        root.find('ul[class*="Meta_slash__"] > li').each((_, tagEl) => {
           const attention = parseAttention($(tagEl).text());
           if (attention) {
             attentions.push(attention);
@@ -117,15 +117,14 @@ export class Kakuyomu implements WebNovelProvider<GetRankOptions> {
           novelId: titleLink.attr('href')
             ? removePrefix('/works/')(titleLink.attr('href')!)
             : '',
-          title: titleLink.text().trim(),
+          title: (titleLink.attr('title') ?? titleLink.text()).trim(),
           attentions,
           keywords: root
-            .find('span.widget-workCard-tags > a')
+            .find('a[href^="/tags/"]')
             .map((_, el) => $(el).text().trim())
             .get(),
           extra: root
-            .find('p.widget-workCard-meta')
-            .children()
+            .find('ul[class*="Meta_disc__"] > li')
             .map((_, el) => $(el).text().trim())
             .get()
             .join(' / '),

--- a/packages/crawler/tests/web/kakuyomu.test.ts
+++ b/packages/crawler/tests/web/kakuyomu.test.ts
@@ -1,8 +1,60 @@
+import ky from 'ky';
 import { describe, expect, test } from 'vitest';
 
 import { Kakuyomu } from '@/web/kakuyomu';
-import { WebNovelType } from '@/web/types';
+import { WebNovelAttention, WebNovelType } from '@/web/types';
 import { client } from './utils';
+
+test('kakuyomu: current ranking page structure', async () => {
+  const html = `
+    <ol class="Rankings_list__currentHash">
+      <li class="Rankings_item__currentHash">
+        <h3>
+          <a title="完整的作品标题" href="/works/1177354054891139802">被截断的作品标题…</a>
+          <a href="/users/example">作者</a>
+        </h3>
+        <ul class="Meta_meta__currentHash Meta_disc__currentHash">
+          <li>★73,252</li>
+          <li>异世界幻想</li>
+          <li>连载中 748话</li>
+        </ul>
+        <ul class="Meta_meta__currentHash Meta_slash__currentHash">
+          <li>残酷描写有り</li>
+          <li>暴力描写有り</li>
+        </ul>
+        <ul class="Meta_meta__currentHash Meta_slash__currentHash">
+          <li><a href="/tags/TS">TS</a></li>
+          <li><a href="/tags/fantasy">剑与魔法</a></li>
+        </ul>
+      </li>
+    </ol>
+  `;
+  const provider = new Kakuyomu(
+    ky.create({
+      fetch: async () =>
+        new Response(html, {
+          status: 200,
+          headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        }),
+    }),
+  );
+
+  const data = await provider.getRank({
+    genre: '综合',
+    range: '总计',
+    status: '全部',
+  });
+
+  expect(data.items).toEqual([
+    {
+      novelId: '1177354054891139802',
+      title: '完整的作品标题',
+      attentions: [WebNovelAttention.Cruelty, WebNovelAttention.Violence],
+      keywords: ['TS', '剑与魔法'],
+      extra: '★73,252 / 异世界幻想 / 连载中 748话',
+    },
+  ]);
+});
 
 describe('kakuyomu', () => {
   const provider = new Kakuyomu(client);

--- a/server/src/main/kotlin/infra/web/datasource/providers/Kakuyomu.kt
+++ b/server/src/main/kotlin/infra/web/datasource/providers/Kakuyomu.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.jsoup.nodes.Document
 
 class Kakuyomu(
     private val client: HttpClient,
@@ -54,41 +55,7 @@ class Kakuyomu(
         val status = statusIds[options["status"]] ?: return emptyPage()
         val url = "https://kakuyomu.jp/rankings/${genre}/${range}?work_variation=${status}"
         val doc = client.get(url).document()
-        val items = doc.select("div.widget-media-genresWorkList-right > div.widget-work").map { workCard ->
-            val a = workCard.selectFirst("a.bookWalker-work-title")!!
-            val novelId = a.attr("href").removePrefix("/works/")
-            val title = a.text()
-
-            val attentions = workCard
-                .select("b.widget-workCard-flags > span")
-                .mapNotNull {
-                    when (it.text()) {
-                        "残酷描写有り" -> WebNovelAttention.残酷描写
-                        "暴力描写有り" -> WebNovelAttention.暴力描写
-                        "性描写有り" -> WebNovelAttention.性描写
-                        else -> null
-                    }
-                }
-
-            val keywords = workCard
-                .select("span.widget-workCard-tags > a")
-                .map { it.text() }
-
-            val extra = workCard.selectFirst("p.widget-workCard-meta")!!.children()
-                .joinToString(" / ") { it.text() }
-
-            RemoteNovelListItem(
-                novelId = novelId,
-                title = title,
-                attentions = attentions,
-                keywords = keywords,
-                extra = extra,
-            )
-        }
-        return Page(
-            items = items,
-            pageNumber = 1L,
-        )
+        return parseKakuyomuRankPage(doc)
     }
 
     override suspend fun getMetadata(novelId: String): RemoteNovelMetadata {
@@ -198,4 +165,43 @@ class Kakuyomu(
         }
         return RemoteChapter(paragraphs = paragraphs)
     }
+}
+
+internal fun parseKakuyomuRankPage(doc: Document): Page<RemoteNovelListItem> {
+    val items = doc.select("li[class*=Rankings_item__]").mapNotNull { workCard ->
+        val a = workCard.selectFirst("h3 a[href^=\"/works/\"]") ?: return@mapNotNull null
+        val novelId = a.attr("href").removePrefix("/works/")
+        val title = a.attr("title").ifBlank { a.text() }.trim()
+
+        val attentions = workCard
+            .select("ul[class*=Meta_slash__] > li")
+            .mapNotNull {
+                when (it.text().trim()) {
+                    "残酷描写有り" -> WebNovelAttention.残酷描写
+                    "暴力描写有り" -> WebNovelAttention.暴力描写
+                    "性描写有り" -> WebNovelAttention.性描写
+                    else -> null
+                }
+            }
+
+        val keywords = workCard
+            .select("a[href^=\"/tags/\"]")
+            .map { it.text().trim() }
+
+        val extra = workCard
+            .select("ul[class*=Meta_disc__] > li")
+            .joinToString(" / ") { it.text().trim() }
+
+        RemoteNovelListItem(
+            novelId = novelId,
+            title = title,
+            attentions = attentions,
+            keywords = keywords,
+            extra = extra,
+        )
+    }
+    return Page(
+        items = items,
+        pageNumber = 1L,
+    )
 }

--- a/server/src/test/kotlin/infra/provider/providers/KakuyomuTest.kt
+++ b/server/src/test/kotlin/infra/provider/providers/KakuyomuTest.kt
@@ -22,7 +22,10 @@ class KakuyomuTest : DescribeSpec(), KoinTest {
     init {
         describe("getRank") {
             it("常规") {
-                provider.getRank(mapOf("genre" to "综合", "range" to "每周"))
+                val rank = provider.getRank(
+                    mapOf("genre" to "综合", "range" to "每周", "status" to "全部")
+                )
+                rank.items.isNotEmpty().shouldBe(true)
             }
         }
 


### PR DESCRIPTION
这个存疑，让 AI 直接 parse 写出来的爬虫，涉及后端就没测（AI 说过了就是过了）

主要是可维护性太差了，server 不切到 crawler 每次改都要维护两个爬虫，不太现实