### PR TITLE
fix(web): fix mobile drawer scrolling

### DIFF
--- a/web/src/components/CDrawerLeft.vue
+++ b/web/src/components/CDrawerLeft.vue
@@ -1,5 +1,10 @@
 <template>
-  <n-drawer :width="280" :auto-focus="false" placement="left">
+  <n-drawer
+    :width="280"
+    :auto-focus="false"
+    placement="left"
+    content-style="height: 100vh; height: 100dvh"
+  >
     <n-drawer-content
       :native-scrollbar="false"
       :scrollbar-props="{ trigger: 'none' }"

--- a/web/src/pages/MainLayout.vue
+++ b/web/src/pages/MainLayout.vue
@@ -445,7 +445,7 @@ watch(
   </n-layout>
 
   <c-drawer-left v-if="!hasSider" v-model:show="showMenuModal">
-    <n-menu :value="menuKey" :options="menuOptions" />
+    <n-menu :value="menuKey" :options="menuOptions" style="flex-shrink: 0" />
     <div style="flex: 1" />
     <div class="sidebar-build-info sidebar-build-info--mobile">
       <div class="sidebar-build-info-item">


### PR DESCRIPTION
修复手机端侧栏展开菜单后无法继续下滑的问题。

复现：手机端打开绿站，点击侧栏，点击展开“小说排行”，会发现菜单无法下滑滚动，下面的设置等被挤出屏幕下方，看不见也滚动不到。

现在给抽屉补充了明确的视口高度，并避免菜单被 flex 压缩，修复后设置和构建信息等都可以正常滚动访问。