### PR TITLE
fix(web): prevent remote proxy from crashing the dev server

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -58,10 +58,10 @@ function setupRemoteAuthProxy(config: UserConfig) {
     changeOrigin: true,
     rewrite: (path: string) => path.replace(/^\/auth-proxy/, ''),
     selfHandleResponse: true,
+    headers: {
+      'accept-encoding': 'identity',
+    },
     configure(proxy) {
-      proxy.on('proxyReq', (proxyReq) => {
-        proxyReq.setHeader('accept-encoding', 'identity');
-      });
       proxy.on('proxyRes', (proxyRes, _req, res) => {
         const chunks: Buffer[] = [];
         proxyRes.on('data', (chunk) => {


### PR DESCRIPTION
修复 dev:remote 模式下访问认证代理会导致 Vite 进程崩溃的问题。

复现：直接在web目录下运行 pnpm dev，即 dev:remote 模式，打开页面时，Vite dev server 会直接退出并报错：

`ERR_HTTP_HEADERS_SENT: Cannot set headers after they are sent to the client`

现在将请求头改为通过代理配置传入，修复后不再出现崩溃问题。