### PR TITLE
feat(web): 增加Ruby标注日语读音

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       ky:
         specifier: ^1.14.0
         version: 1.14.3
+      lindera-wasm-ipadic:
+        specifier: ^2.1.0
+        version: 2.1.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -288,6 +291,9 @@ importers:
       vue-tsc:
         specifier: ^2.2.12
         version: 2.2.12(typescript@5.9.3)
+      wanakana:
+        specifier: ^5.3.1
+        version: 5.3.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.35.0
@@ -4204,6 +4210,12 @@ packages:
       }
     engines: { node: '>= 12.0.0' }
 
+  lindera-wasm-ipadic@2.1.0:
+    resolution:
+      {
+        integrity: sha512-KdUku5OKNfbswatINoiTPAi63SskH4uw4OVTodtQZiZwOP3VkSjR4DIs+/MZmGS8ydUXBIDdCxxRl3+jBVHhZw==,
+      }
+
   linkify-it@5.0.0:
     resolution:
       {
@@ -5890,6 +5902,13 @@ packages:
       }
     peerDependencies:
       vue: ^3.0.11
+
+  wanakana@5.3.1:
+    resolution:
+      {
+        integrity: sha512-OSDqupzTlzl2LGyqTdhcXcl6ezMiFhcUwLBP8YKaBIbMYW1wAwDvupw2T9G9oVaKT9RmaSpyTXjxddFPUcFFIw==,
+      }
+    engines: { node: '>=12' }
 
   webpack-virtual-modules@0.6.2:
     resolution:
@@ -8279,6 +8298,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lindera-wasm-ipadic@2.1.0: {}
+
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
@@ -9399,6 +9420,8 @@ snapshots:
       vdirs: 0.1.8(vue@3.5.32(typescript@5.9.3))
       vooks: 0.2.12(vue@3.5.32(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
+
+  wanakana@5.3.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -62,6 +62,7 @@
     "idb": "^8.0.3",
     "jwt-decode": "^4.0.0",
     "ky": "^1.14.0",
+    "lindera-wasm-ipadic": "^2.1.0",
     "lodash-es": "^4.18.1",
     "markdown-it": "^14.1.0",
     "markdown-it-anchor": "^9.2.0",
@@ -79,6 +80,7 @@
     "vue": "^3.5.32",
     "vue-draggable-plus": "^0.5.6",
     "vue-router": "^5.0.4",
-    "vue-tsc": "^2.2.12"
+    "vue-tsc": "^2.2.12",
+    "wanakana": "^5.3.1"
   }
 }

--- a/web/src/pages/reader/components/BuildParagraphs.ts
+++ b/web/src/pages/reader/components/BuildParagraphs.ts
@@ -10,6 +10,7 @@ export type ReaderParagraph =
       source?: string;
       secondary: boolean;
       needSpeak: boolean;
+      language: 'jp' | 'zh';
     }
   | { imageUrl: string }
   | undefined;
@@ -27,6 +28,7 @@ export const buildParagraphs = (
     source?: string;
     secondary: boolean;
     needSpeak: boolean;
+    language: 'jp' | 'zh';
   }[] = [];
   const needSpeakJp =
     setting.mode === 'jp' || setting.speakLanguages.includes('jp');
@@ -39,6 +41,7 @@ export const buildParagraphs = (
       source: 'J',
       secondary: false,
       needSpeak: needSpeakJp,
+      language: 'jp',
     });
   } else {
     if (setting.mode === 'jp-zh') {
@@ -47,6 +50,7 @@ export const buildParagraphs = (
         source: 'J',
         secondary: true,
         needSpeak: needSpeakJp,
+        language: 'jp',
       });
     }
 
@@ -72,6 +76,7 @@ export const buildParagraphs = (
             source: t[0].toUpperCase(),
             secondary: false,
             needSpeak: needSpeakZh,
+            language: 'zh',
           });
           break;
         } else {
@@ -80,6 +85,7 @@ export const buildParagraphs = (
             text: label + '翻译不存在',
             secondary: true,
             needSpeak: true,
+            language: 'zh',
           });
         }
       }
@@ -96,6 +102,7 @@ export const buildParagraphs = (
             source: t[0].toUpperCase(),
             secondary: false,
             needSpeak: needSpeakZh && i === 0,
+            language: 'zh',
           });
         } else {
           merged.push({
@@ -103,6 +110,7 @@ export const buildParagraphs = (
             text: label + '翻译不存在',
             secondary: true,
             needSpeak: true,
+            language: 'zh',
           });
         }
         i++;
@@ -115,6 +123,7 @@ export const buildParagraphs = (
         source: 'J',
         secondary: true,
         needSpeak: needSpeakJp,
+        language: 'jp',
       });
     }
   }
@@ -149,6 +158,7 @@ export const buildParagraphs = (
           source: style.source,
           secondary: style.secondary,
           needSpeak: style.needSpeak,
+          language: style.language,
         });
       }
     }

--- a/web/src/pages/reader/components/JapaneseRubyText.vue
+++ b/web/src/pages/reader/components/JapaneseRubyText.vue
@@ -1,0 +1,50 @@
+<script lang="ts" setup>
+import type { RubySegment } from '../ruby/types';
+
+const props = defineProps<{
+  enabled: boolean;
+  text: string;
+}>();
+
+const segments = shallowRef<RubySegment[]>([{ text: props.text }]);
+let revision = 0;
+
+watch(
+  () => [props.enabled, props.text] as const,
+  async ([enabled, text]) => {
+    const currentRevision = ++revision;
+    segments.value = [{ text }];
+    if (!enabled || !/\p{Script=Han}/u.test(text)) return;
+
+    try {
+      const { annotateJapanese } = await import('../ruby/JapaneseRuby');
+      const annotated = await annotateJapanese(text);
+      if (revision === currentRevision) segments.value = annotated;
+    } catch (error) {
+      console.error('[reader-ruby] 无法标注日语读音', error);
+    }
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <template v-for="(segment, index) in segments" :key="index">
+    <!-- prettier-ignore -->
+    <ruby v-if="segment.reading">{{ segment.text }}<rp aria-hidden="true">(</rp><rt aria-hidden="true">{{ segment.reading }}</rt><rp aria-hidden="true">)</rp></ruby>
+    <template v-else>{{ segment.text }}</template>
+  </template>
+</template>
+
+<style scoped>
+rt,
+rp {
+  text-decoration: none;
+  user-select: none;
+}
+
+rt {
+  font-weight: 400;
+  opacity: 0.7;
+}
+</style>

--- a/web/src/pages/reader/components/ReaderContent.vue
+++ b/web/src/pages/reader/components/ReaderContent.vue
@@ -59,7 +59,12 @@ const chapterHref = computed(() => {
 <template>
   <div class="chapter" data-chapter :data-id="chapterId">
     <n-h4 class="chapter-title">
-      <n-a :href="chapterHref">{{ chapter.titleJp }}</n-a>
+      <n-a :href="chapterHref">
+        <japanese-ruby-text
+          :text="chapter.titleJp"
+          :enabled="readerSetting.showJapaneseReading"
+        />
+      </n-a>
       <br />
       <n-text depth="3">{{ chapter.titleZh }}</n-text>
       <br />
@@ -82,7 +87,12 @@ const chapterHref = computed(() => {
             {{ p.indent }}
           </span>
           <span :class="[p.secondary ? 'second' : 'first', 'text-content']">
-            {{ p.text }}
+            <japanese-ruby-text
+              :text="p.text"
+              :enabled="
+                readerSetting.showJapaneseReading && p.language === 'jp'
+              "
+            />
           </span>
         </n-p>
         <br v-else-if="!p" />

--- a/web/src/pages/reader/components/ReaderSettingModal.vue
+++ b/web/src/pages/reader/components/ReaderSettingModal.vue
@@ -88,7 +88,7 @@ const setIndentSize = (diff: number) => {
               size="small"
             />
           </c-action-wrapper>
-          <c-action-wrapper title="显示日语读音" align="center">
+          <c-action-wrapper title="标注日语读音（仅参考）" align="center">
             <n-switch
               v-model:value="readerSetting.showJapaneseReading"
               size="small"

--- a/web/src/pages/reader/components/ReaderSettingModal.vue
+++ b/web/src/pages/reader/components/ReaderSettingModal.vue
@@ -88,6 +88,12 @@ const setIndentSize = (diff: number) => {
               size="small"
             />
           </c-action-wrapper>
+          <c-action-wrapper title="显示日语读音" align="center">
+            <n-switch
+              v-model:value="readerSetting.showJapaneseReading"
+              size="small"
+            />
+          </c-action-wrapper>
           <c-action-wrapper title="缩进修正" align="center">
             <n-flex size="large" align="center">
               <n-switch

--- a/web/src/pages/reader/ruby/JapaneseRuby.ts
+++ b/web/src/pages/reader/ruby/JapaneseRuby.ts
@@ -1,0 +1,59 @@
+import type { RubyRequest, RubyResponse, RubySegment } from './types';
+
+interface PendingRequest {
+  reject(error: Error): void;
+  resolve(segments: RubySegment[]): void;
+}
+
+const cache = new Map<string, Promise<RubySegment[]>>();
+const pending = new Map<number, PendingRequest>();
+let nextRequestId = 0;
+let worker: Worker | undefined;
+
+export function annotateJapanese(text: string): Promise<RubySegment[]> {
+  const cached = cache.get(text);
+  if (cached) return cached;
+
+  const request = requestAnnotation(text).catch((error) => {
+    cache.delete(text);
+    throw error;
+  });
+  cache.set(text, request);
+  if (cache.size > 300) cache.delete(cache.keys().next().value!);
+  return request;
+}
+
+function requestAnnotation(text: string): Promise<RubySegment[]> {
+  const rubyWorker = getWorker();
+  const id = nextRequestId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    rubyWorker.postMessage({ id, text } satisfies RubyRequest);
+  });
+}
+
+function getWorker(): Worker {
+  if (worker) return worker;
+
+  worker = new Worker(new URL('./JapaneseRuby.worker.ts', import.meta.url), {
+    type: 'module',
+  });
+  worker.onmessage = ({ data }: MessageEvent<RubyResponse>) => {
+    const request = pending.get(data.id);
+    if (!request) return;
+    pending.delete(data.id);
+    if ('error' in data) {
+      request.reject(new Error(data.error));
+    } else {
+      request.resolve(data.segments);
+    }
+  };
+  worker.onerror = ({ message }) => {
+    const error = new Error(message || '日语读音处理线程加载失败');
+    for (const request of pending.values()) request.reject(error);
+    pending.clear();
+    worker?.terminate();
+    worker = undefined;
+  };
+  return worker;
+}

--- a/web/src/pages/reader/ruby/JapaneseRuby.worker.ts
+++ b/web/src/pages/reader/ruby/JapaneseRuby.worker.ts
@@ -1,0 +1,61 @@
+import initLindera, {
+  type Token,
+  type Tokenizer,
+  TokenizerBuilder,
+} from 'lindera-wasm-ipadic';
+
+import { buildRubySegments } from './JapaneseRubyTokens';
+import type { RubyRequest, RubyResponse } from './types';
+
+interface WorkerScope {
+  onmessage: ((event: MessageEvent<RubyRequest>) => void) | null;
+  postMessage(message: RubyResponse): void;
+}
+
+const workerScope = globalThis as unknown as WorkerScope;
+let tokenizerPromise: Promise<Tokenizer> | undefined;
+
+workerScope.onmessage = async ({ data }) => {
+  try {
+    const tokenizer = await getTokenizer();
+    const tokens = tokenizer.tokenize(data.text).map(toSourceToken);
+    workerScope.postMessage({
+      id: data.id,
+      segments: buildRubySegments(tokens, data.text),
+    });
+  } catch (error) {
+    workerScope.postMessage({
+      id: data.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+function getTokenizer(): Promise<Tokenizer> {
+  if (!tokenizerPromise) {
+    tokenizerPromise = (async () => {
+      await initLindera();
+      const builder = new TokenizerBuilder();
+      builder.setDictionary('embedded://ipadic');
+      builder.setMode('normal');
+      builder.appendCharacterFilter('unicode_normalize', { kind: 'nfkc' });
+      builder.appendTokenFilter('lowercase', {});
+      builder.appendTokenFilter('japanese_compound_word', {
+        kind: 'ipadic',
+        tags: ['名詞,数'],
+        new_tag: '名詞,数',
+      });
+      return builder.build();
+    })();
+  }
+  return tokenizerPromise;
+}
+
+function toSourceToken(token: Token) {
+  return {
+    byteStart: token.byte_start,
+    byteEnd: token.byte_end,
+    text: token.surface,
+    reading: token.details[7] ?? '*',
+  };
+}

--- a/web/src/pages/reader/ruby/JapaneseRubyTokens.ts
+++ b/web/src/pages/reader/ruby/JapaneseRubyTokens.ts
@@ -16,6 +16,11 @@ interface RubyToken {
   start: number;
 }
 
+interface TextRange {
+  end: number;
+  start: number;
+}
+
 type SimplifiedToken = RubyToken;
 
 interface KanaChunk {
@@ -54,6 +59,8 @@ export function buildRubySegments(
 }
 
 function toKanjiTokens(tokens: SourceToken[], text: string): RubyToken[] {
+  const uncertainRanges = findUncertainKanjiRanges(tokens, text);
+
   return tokens
     .filter(
       (token) =>
@@ -66,7 +73,42 @@ function toKanjiTokens(tokens: SourceToken[], text: string): RubyToken[] {
       original: token.text,
       reading: token.reading,
     }))
+    .filter(
+      (token) =>
+        !uncertainRanges.some(
+          (range) => token.start < range.end && token.end > range.start,
+        ),
+    )
     .flatMap(splitMixedToken);
+}
+
+function findUncertainKanjiRanges(
+  tokens: SourceToken[],
+  text: string,
+): TextRange[] {
+  const unknownRanges = tokens
+    .filter(
+      (token) =>
+        /\p{Script=Han}/u.test(token.text) &&
+        (!token.reading || token.reading === '*'),
+    )
+    .map<TextRange>((token) => ({
+      start: byteToUtf16(token.byteStart, text),
+      end: byteToUtf16(token.byteEnd, text),
+    }));
+  if (unknownRanges.length === 0) return [];
+
+  return Array.from(
+    text.matchAll(/[\p{Script=Han}々〆ヵヶ]+/gu),
+    (match): TextRange => ({
+      start: match.index,
+      end: match.index + match[0].length,
+    }),
+  ).filter((range) =>
+    unknownRanges.some(
+      (unknown) => unknown.start < range.end && unknown.end > range.start,
+    ),
+  );
 }
 
 export function byteToUtf16(byteIndex: number, text: string): number {

--- a/web/src/pages/reader/ruby/JapaneseRubyTokens.ts
+++ b/web/src/pages/reader/ruby/JapaneseRubyTokens.ts
@@ -1,0 +1,128 @@
+import { isKanji, toHiragana, toKatakana } from 'wanakana';
+
+import type { RubySegment } from './types';
+
+export interface SourceToken {
+  byteEnd: number;
+  byteStart: number;
+  reading: string;
+  text: string;
+}
+
+interface RubyToken {
+  end: number;
+  original: string;
+  reading: string;
+  start: number;
+}
+
+type SimplifiedToken = RubyToken;
+
+interface KanaChunk {
+  end: number;
+  original: string;
+  start: number;
+}
+
+export function buildRubySegments(
+  tokens: SourceToken[],
+  text: string,
+): RubySegment[] {
+  const rubyTokens = toKanjiTokens(tokens, text)
+    .filter(
+      (token) =>
+        token.start >= 0 && token.end <= text.length && token.start < token.end,
+    )
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+
+  const segments: RubySegment[] = [];
+  let cursor = 0;
+  for (const token of rubyTokens) {
+    if (token.start < cursor) continue;
+    if (token.start > cursor) {
+      segments.push({ text: text.slice(cursor, token.start) });
+    }
+    segments.push({
+      text: token.original,
+      reading: toHiragana(token.reading),
+    });
+    cursor = token.end;
+  }
+  if (cursor < text.length) segments.push({ text: text.slice(cursor) });
+
+  return segments.length > 0 ? segments : [{ text }];
+}
+
+function toKanjiTokens(tokens: SourceToken[], text: string): RubyToken[] {
+  return tokens
+    .filter(
+      (token) =>
+        /\p{Script=Han}/u.test(token.text) &&
+        Boolean(token.reading && token.reading !== '*'),
+    )
+    .map<SimplifiedToken>((token) => ({
+      start: byteToUtf16(token.byteStart, text),
+      end: byteToUtf16(token.byteEnd, text),
+      original: token.text,
+      reading: token.reading,
+    }))
+    .flatMap(splitMixedToken);
+}
+
+export function byteToUtf16(byteIndex: number, text: string): number {
+  const encoder = new TextEncoder();
+  let bytes = 0;
+  let utf16Index = 0;
+  for (const character of text) {
+    bytes += encoder.encode(character).length;
+    if (bytes > byteIndex) return utf16Index;
+    utf16Index += character.length;
+  }
+  return utf16Index;
+}
+
+function splitMixedToken(token: SimplifiedToken): RubyToken[] {
+  if (isKanji(token.original)) return [token];
+
+  const kanaChunks = Array.from(
+    token.original.matchAll(/[\p{Script=Hiragana}\p{Script=Katakana}ー]+/gu),
+    (match): KanaChunk => ({
+      original: toKatakana(match[0]),
+      start: match.index,
+      end: match.index + match[0].length,
+    }),
+  );
+  if (kanaChunks.length === 0) return [token];
+
+  const readingPattern = buildReadingPattern(kanaChunks, token.original.length);
+  const readingParts = token.reading.match(readingPattern)?.slice(1);
+  const kanjiMatches = Array.from(token.original.matchAll(/\p{Script=Han}+/gu));
+  if (!readingParts || readingParts.length !== kanjiMatches.length) {
+    return [token];
+  }
+
+  return kanjiMatches.map((match, index) => ({
+    original: match[0],
+    reading: readingParts[index]!,
+    start: token.start + match.index,
+    end: token.start + match.index + match[0].length,
+  }));
+}
+
+function buildReadingPattern(
+  kanaChunks: KanaChunk[],
+  originalLength: number,
+): RegExp {
+  const first = kanaChunks[0]!;
+  const last = kanaChunks[kanaChunks.length - 1]!;
+  let pattern = '^';
+
+  if (first.start > 0) pattern += '(.+)';
+  for (const chunk of kanaChunks) {
+    pattern += chunk.original;
+    if (chunk !== last) pattern += '(.+)';
+  }
+  if (last.end !== originalLength) pattern += '(.+)';
+
+  return new RegExp(`${pattern}$`, 'u');
+}

--- a/web/src/pages/reader/ruby/types.ts
+++ b/web/src/pages/reader/ruby/types.ts
@@ -1,0 +1,13 @@
+export interface RubySegment {
+  text: string;
+  reading?: string;
+}
+
+export interface RubyRequest {
+  id: number;
+  text: string;
+}
+
+export type RubyResponse =
+  | { id: number; segments: RubySegment[] }
+  | { id: number; error: string };

--- a/web/src/stores/useSettingStore.ts
+++ b/web/src/stores/useSettingStore.ts
@@ -179,6 +179,7 @@ export interface ReaderSetting {
   enableClickAnimition: boolean;
   indentSize?: number;
   enableSourceLabel: boolean;
+  showJapaneseReading: boolean;
   //
   fontWeight: number;
   fontSize: number;
@@ -204,6 +205,7 @@ export namespace ReaderSetting {
     pageTurnMode: 'page',
     enableClickAnimition: true,
     enableSourceLabel: false,
+    showJapaneseReading: false,
     //
     fontWeight: 400,
     fontSize: 14,
@@ -253,6 +255,7 @@ export namespace ReaderSetting {
       }
       delete setting.trimLeadingSpaces;
     }
+    setting.showJapaneseReading ??= false;
     setting.translations = sanitizeTranslators(
       setting.translations,
       defaultTranslationPriority,

--- a/web/tests/japaneseRuby.test.ts
+++ b/web/tests/japaneseRuby.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRubySegments,
+  byteToUtf16,
+  type SourceToken,
+} from '../src/pages/reader/ruby/JapaneseRubyTokens';
+
+describe('Japanese ruby token conversion', () => {
+  it('splits the kanji out of mixed kanji-kana words', () => {
+    const text = '食べる';
+    const tokens: SourceToken[] = [
+      {
+        byteStart: 0,
+        byteEnd: new TextEncoder().encode(text).length,
+        text,
+        reading: 'タベル',
+      },
+    ];
+
+    expect(buildRubySegments(tokens, text)).toEqual([
+      { text: '食', reading: 'た' },
+      { text: 'べる' },
+    ]);
+  });
+
+  it('keeps UTF-8 byte offsets aligned with UTF-16 rendering offsets', () => {
+    const text = '😀東京へ';
+    const tokens: SourceToken[] = [
+      {
+        byteStart: 4,
+        byteEnd: 10,
+        text: '東京',
+        reading: 'トウキョウ',
+      },
+    ];
+
+    expect(byteToUtf16(4, text)).toBe(2);
+    expect(buildRubySegments(tokens, text)).toEqual([
+      { text: '😀' },
+      { text: '東京', reading: 'とうきょう' },
+      { text: 'へ' },
+    ]);
+  });
+});

--- a/web/tests/japaneseRuby.test.ts
+++ b/web/tests/japaneseRuby.test.ts
@@ -42,4 +42,44 @@ describe('Japanese ruby token conversion', () => {
       { text: 'へ' },
     ]);
   });
+
+  it('does not annotate a kanji run containing an unknown token', () => {
+    const text = '人妖大乱中には大将軍と妖母、対妖用に特化した。';
+    const tokens: SourceToken[] = [
+      tokenAt(text, 0, 1, 'ヒト'),
+      tokenAt(text, 1, 2, '*'),
+      tokenAt(text, 2, 4, 'タイラン'),
+      tokenAt(text, 4, 5, 'チュウ'),
+      tokenAt(text, 7, 10, 'ダイショウグン'),
+      tokenAt(text, 11, 12, '*'),
+      tokenAt(text, 12, 13, 'ハハ'),
+      tokenAt(text, 14, 15, 'タイ'),
+      tokenAt(text, 15, 16, '*'),
+      tokenAt(text, 16, 17, 'ヨウ'),
+      tokenAt(text, 18, 20, 'トッカ'),
+    ];
+
+    expect(buildRubySegments(tokens, text)).toEqual([
+      { text: '人妖大乱中には' },
+      { text: '大将軍', reading: 'だいしょうぐん' },
+      { text: 'と妖母、対妖用に' },
+      { text: '特化', reading: 'とっか' },
+      { text: 'した。' },
+    ]);
+  });
 });
+
+function tokenAt(
+  text: string,
+  start: number,
+  end: number,
+  reading: string,
+): SourceToken {
+  const encoder = new TextEncoder();
+  return {
+    byteStart: encoder.encode(text.slice(0, start)).length,
+    byteEnd: encoder.encode(text.slice(0, end)).length,
+    text: text.slice(start, end),
+    reading,
+  };
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -56,12 +56,12 @@ function setupRemoteAuthProxy(config: UserConfig) {
   proxy['/auth-proxy'] = {
     target: AuthUrl,
     changeOrigin: true,
+    headers: {
+      'accept-encoding': 'identity',
+    },
     rewrite: (path: string) => path.replace(/^\/auth-proxy/, ''),
     selfHandleResponse: true,
     configure(proxy) {
-      proxy.on('proxyReq', (proxyReq) => {
-        proxyReq.setHeader('accept-encoding', 'identity');
-      });
       proxy.on('proxyRes', (proxyRes, _req, res) => {
         const chunks: Buffer[] = [];
         proxyRes.on('data', (chunk) => {
@@ -126,7 +126,14 @@ export default defineConfig(({ mode }) => {
         treeshake: true,
         output: {
           manualChunks(id) {
-            if (id.includes('web/src')) {
+            if (
+              id.includes('lindera-wasm-ipadic') ||
+              id.includes('/wanakana/')
+            ) {
+              return 'dep-reader-ruby';
+            } else if (id.includes('/pages/reader/ruby/')) {
+              return 'reader-ruby';
+            } else if (id.includes('web/src')) {
               return 'chunk';
             } else if (id.includes('@zip.js')) {
               return 'dep-zip';


### PR DESCRIPTION
使用 lindera-wasm-ipadic 进行标注。选项没开不会加载相关包，以免让 bundle 体积过大。

由于中文和日文的前后顺序可调整，所以没有好的办法识别哪些该检测。为了识别是中文还是日文增加了一个 language 字段。

<img width="1061" height="781" alt="image" src="https://github.com/user-attachments/assets/d98c93c6-ef10-48c1-9bd1-f326e47b1944" />
<img width="1311" height="1083" alt="image" src="https://github.com/user-attachments/assets/9ff28cf6-bb52-466c-9e34-a1d19419883a" />

