### PR TITLE
fix(web): 優化 Markdown toolbar 吸頂效果

### DIFF
--- a/web/src/components/markdown/MarkdownEditor.vue
+++ b/web/src/components/markdown/MarkdownEditor.vue
@@ -26,18 +26,11 @@ const props = withDefaults(
   },
 );
 
-const showTopTooltip = ref<boolean | undefined>(undefined);
-const showBottomTooltip = ref<boolean | undefined>(undefined);
-
 const scrollToTop = (event: MouseEvent) => {
   window.scrollTo({ top: 0, behavior: 'smooth' });
-  showTopTooltip.value = false;
   if (event.currentTarget) {
     (event.currentTarget as HTMLButtonElement).blur();
   }
-  setTimeout(() => {
-    showTopTooltip.value = undefined;
-  }, 500);
 };
 
 const scrollToBottom = (event: MouseEvent) => {
@@ -45,13 +38,9 @@ const scrollToBottom = (event: MouseEvent) => {
     top: document.documentElement.scrollHeight,
     behavior: 'smooth',
   });
-  showBottomTooltip.value = false;
   if (event.currentTarget) {
     (event.currentTarget as HTMLButtonElement).blur();
   }
-  setTimeout(() => {
-    showBottomTooltip.value = undefined;
-  }, 500);
 };
 
 const value = defineModel<string>('value', { required: true });
@@ -68,6 +57,7 @@ const isWideScreen = useIsWideScreen(620);
 const showEditorToolbar = ref(true);
 const onTabUpdate = (val: number) => {
   showEditorToolbar.value = val === 0;
+  nextTick(updateStickyToolbar);
 };
 
 // ==============================
@@ -98,14 +88,14 @@ const clearDraft = () => {
 
 const elEditor = useTemplateRef('editor');
 const editorRoot = useTemplateRef<HTMLElement>('editorRoot');
-const toolbarHost = useTemplateRef<HTMLElement>('toolbarHost');
-const toolbarSurface = useTemplateRef<HTMLElement>('toolbarSurface');
+const tabsInst = useTemplateRef<any>('tabsInst');
 
 const toolbarFixed = ref(false);
-const toolbarFixedStyle = ref<Record<string, string>>({});
+const placeholderHeight = ref(0);
 
 let toolbarUpdateFrame: number | undefined;
 let toolbarResizeObserver: ResizeObserver | undefined;
+
 const updateStickyToolbar = () => {
   if (toolbarUpdateFrame !== undefined) return;
 
@@ -113,25 +103,53 @@ const updateStickyToolbar = () => {
     toolbarUpdateFrame = undefined;
 
     const root = editorRoot.value;
-    const host = toolbarHost.value;
-    const surface = toolbarSurface.value;
-    if (!props.sticky || !root || !host || !surface) {
-      toolbarFixed.value = false;
+    const tabsEl = tabsInst.value?.$el as HTMLElement | undefined;
+    const navEl = tabsEl?.querySelector('.n-tabs-nav') as
+      | HTMLElement
+      | undefined;
+
+    if (!props.sticky || !root || !tabsEl || !navEl) {
+      if (toolbarFixed.value) {
+        toolbarFixed.value = false;
+        placeholderHeight.value = 0;
+        if (navEl) {
+          navEl.classList.remove('is-fixed');
+          navEl.style.position = '';
+          navEl.style.top = '';
+          navEl.style.left = '';
+          navEl.style.width = '';
+          navEl.style.zIndex = '';
+        }
+      }
       return;
     }
 
     const rootRect = root.getBoundingClientRect();
-    const hostRect = host.getBoundingClientRect();
-    const toolbarHeight = surface.offsetHeight;
-    const shouldFix = hostRect.top <= props.stickyTop && rootRect.bottom > 0;
+    const tabsRect = tabsEl.getBoundingClientRect();
+    const toolbarHeight = navEl.offsetHeight;
+    const shouldFix =
+      tabsRect.top <= props.stickyTop &&
+      rootRect.bottom > props.stickyTop + toolbarHeight;
 
     toolbarFixed.value = shouldFix;
     if (shouldFix) {
-      toolbarFixedStyle.value = {
+      placeholderHeight.value = toolbarHeight;
+      navEl.classList.add('is-fixed');
+      Object.assign(navEl.style, {
+        position: 'fixed',
         top: `${Math.min(props.stickyTop, rootRect.bottom - toolbarHeight)}px`,
-        left: `${hostRect.left}px`,
-        width: `${hostRect.width}px`,
-      };
+        left: `${tabsRect.left}px`,
+        width: `${tabsRect.width}px`,
+        zIndex: '10',
+      });
+    } else {
+      placeholderHeight.value = 0;
+      navEl.classList.remove('is-fixed');
+      navEl.style.position = '';
+      navEl.style.top = '';
+      navEl.style.left = '';
+      navEl.style.width = '';
+      navEl.style.zIndex = '';
     }
   });
 };
@@ -144,7 +162,7 @@ onMounted(() => {
 
   toolbarResizeObserver = new ResizeObserver(updateStickyToolbar);
   if (editorRoot.value) toolbarResizeObserver.observe(editorRoot.value);
-  if (toolbarHost.value) toolbarResizeObserver.observe(toolbarHost.value);
+  if (tabsInst.value?.$el) toolbarResizeObserver.observe(tabsInst.value.$el);
 });
 
 onBeforeUnmount(() => {
@@ -161,150 +179,132 @@ watch([isWideScreen, () => props.sticky], () => nextTick(updateStickyToolbar));
   <div ref="editorRoot" class="markdown-editor-boundary">
     <n-el tag="div" class="markdown-input">
       <n-tabs
-        ref="tab"
+        ref="tabsInst"
         class="tabs"
         type="card"
         size="small"
         @update:value="onTabUpdate"
       >
-        <template v-if="isWideScreen" #suffix>
-          <div ref="toolbarHost" class="markdown-toolbar-host">
-            <div
-              ref="toolbarSurface"
-              class="markdown-toolbar-surface"
-              :class="{ 'is-fixed': toolbarFixed }"
-              :style="toolbarFixed ? toolbarFixedStyle : undefined"
+        <template #suffix>
+          <!-- Desktop Layout -->
+          <div v-if="isWideScreen" class="markdown-toolbar-surface">
+            <n-flex
+              :size="8"
+              align="center"
+              style="padding: 0 8px; width: 100%; height: 100%"
+              :wrap="false"
             >
-              <n-flex
-                :size="8"
-                align="center"
-                style="padding: 0 8px; width: 100%"
-                :wrap="false"
-              >
-                <template v-if="showScrollButtons">
-                  <n-tooltip
-                    trigger="hover"
-                    :placement="sticky ? 'bottom' : 'top'"
-                    :show="showTopTooltip"
-                  >
-                    <template #trigger>
-                      <n-button
-                        size="small"
-                        quaternary
-                        style="padding: 0 8px"
-                        @click="scrollToTop"
-                      >
-                        <template #icon>
-                          <n-icon :component="ArrowUpwardOutlined" />
-                        </template>
-                      </n-button>
-                    </template>
-                    回到頁首
-                  </n-tooltip>
-                  <n-tooltip
-                    trigger="hover"
-                    :placement="sticky ? 'bottom' : 'top'"
-                    :show="showBottomTooltip"
-                  >
-                    <template #trigger>
-                      <n-button
-                        size="small"
-                        quaternary
-                        style="padding: 0 8px"
-                        @click="scrollToBottom"
-                      >
-                        <template #icon>
-                          <n-icon :component="ArrowDownwardOutlined" />
-                        </template>
-                      </n-button>
-                    </template>
-                    回到頁尾
-                  </n-tooltip>
-                  <n-divider
-                    v-if="showEditorToolbar && isWideScreen"
-                    vertical
-                    style="margin: 0 4px"
-                  />
-                </template>
-
-                <div style="flex: 1" />
-
-                <MarkdownToolbar
-                  v-if="showEditorToolbar && isWideScreen"
-                  :el-textarea="elEditor?.textareaElRef ?? undefined"
-                  :drafts="drafts"
-                  :tooltip-placement="sticky ? 'bottom' : 'top'"
-                  @clear-draft="clearDraft"
+              <template v-if="showScrollButtons">
+                <n-tooltip trigger="hover" placement="top">
+                  <template #trigger>
+                    <n-button
+                      size="small"
+                      quaternary
+                      style="padding: 0 8px"
+                      @click="scrollToTop"
+                    >
+                      <template #icon>
+                        <n-icon :component="ArrowUpwardOutlined" />
+                      </template>
+                    </n-button>
+                  </template>
+                  回到頁首
+                </n-tooltip>
+                <n-tooltip trigger="hover" placement="top">
+                  <template #trigger>
+                    <n-button
+                      size="small"
+                      quaternary
+                      style="padding: 0 8px"
+                      @click="scrollToBottom"
+                    >
+                      <template #icon>
+                        <n-icon :component="ArrowDownwardOutlined" />
+                      </template>
+                    </n-button>
+                  </template>
+                  回到頁尾
+                </n-tooltip>
+                <n-divider
+                  v-if="showEditorToolbar"
+                  vertical
+                  style="margin: 0 4px"
                 />
+              </template>
+
+              <div style="flex: 1" />
+
+              <MarkdownToolbar
+                v-if="showEditorToolbar"
+                :el-textarea="elEditor?.textareaElRef ?? undefined"
+                :drafts="drafts"
+                tooltip-placement="top"
+                @clear-draft="clearDraft"
+              />
+            </n-flex>
+          </div>
+
+          <!-- Mobile Layout -->
+          <template v-else>
+            <div class="mobile-jump-buttons">
+              <n-flex
+                v-if="showScrollButtons"
+                :size="4"
+                align="center"
+                :wrap="false"
+                style="height: 100%"
+              >
+                <n-tooltip trigger="hover" placement="top">
+                  <template #trigger>
+                    <n-button
+                      size="small"
+                      quaternary
+                      style="padding: 0 6px"
+                      @click="scrollToTop"
+                    >
+                      <template #icon>
+                        <n-icon :component="ArrowUpwardOutlined" />
+                      </template>
+                    </n-button>
+                  </template>
+                  回到頁首
+                </n-tooltip>
+                <n-tooltip trigger="hover" placement="top">
+                  <template #trigger>
+                    <n-button
+                      size="small"
+                      quaternary
+                      style="padding: 0 6px"
+                      @click="scrollToBottom"
+                    >
+                      <template #icon>
+                        <n-icon :component="ArrowDownwardOutlined" />
+                      </template>
+                    </n-button>
+                  </template>
+                  回到頁尾
+                </n-tooltip>
               </n-flex>
             </div>
-          </div>
+
+            <div v-if="showEditorToolbar" class="mobile-toolbar-line2">
+              <MarkdownToolbar
+                :el-textarea="elEditor?.textareaElRef ?? undefined"
+                :drafts="drafts"
+                tooltip-placement="top"
+                @clear-draft="clearDraft"
+              />
+            </div>
+          </template>
         </template>
+
         <n-tab-pane tab="编辑" :name="0" display-directive="show">
           <div
-            v-if="!isWideScreen"
-            ref="toolbarHost"
-            class="markdown-toolbar-host mobile-toolbar-host"
-          >
-            <div
-              ref="toolbarSurface"
-              class="markdown-toolbar-surface mobile-toolbar"
-              :class="{ 'is-fixed': toolbarFixed }"
-              :style="toolbarFixed ? toolbarFixedStyle : undefined"
-            >
-              <n-flex :size="0" align="center">
-                <template v-if="showScrollButtons">
-                  <n-tooltip
-                    trigger="hover"
-                    placement="bottom"
-                    :show="showTopTooltip"
-                  >
-                    <template #trigger>
-                      <n-button
-                        size="small"
-                        quaternary
-                        style="padding: 0 8px"
-                        @click="scrollToTop"
-                      >
-                        <template #icon>
-                          <n-icon :component="ArrowUpwardOutlined" />
-                        </template>
-                      </n-button>
-                    </template>
-                    回到頁首
-                  </n-tooltip>
-                  <n-tooltip
-                    trigger="hover"
-                    placement="bottom"
-                    :show="showBottomTooltip"
-                  >
-                    <template #trigger>
-                      <n-button
-                        size="small"
-                        quaternary
-                        style="padding: 0 8px"
-                        @click="scrollToBottom"
-                      >
-                        <template #icon>
-                          <n-icon :component="ArrowDownwardOutlined" />
-                        </template>
-                      </n-button>
-                    </template>
-                    回到頁尾
-                  </n-tooltip>
-                  <n-divider vertical style="margin: 0 4px" />
-                </template>
-                <MarkdownToolbar
-                  :el-textarea="elEditor?.textareaElRef ?? undefined"
-                  :drafts="drafts"
-                  tooltip-placement="bottom"
-                  @clear-draft="clearDraft"
-                />
-              </n-flex>
-            </div>
-          </div>
-
-          <div style="padding: 0 8px 8px">
+            v-if="toolbarFixed"
+            class="toolbar-placeholder"
+            :style="{ height: `${placeholderHeight}px` }"
+          />
+          <div class="editor-input-wrapper">
             <n-input
               ref="editor"
               v-bind="$attrs"
@@ -317,8 +317,14 @@ watch([isWideScreen, () => props.sticky], () => nextTick(updateStickyToolbar));
             />
           </div>
         </n-tab-pane>
+
         <n-tab-pane tab="预览" :name="1">
-          <div style="padding: 0px 16px">
+          <div
+            v-if="toolbarFixed"
+            class="toolbar-placeholder"
+            :style="{ height: `${placeholderHeight}px` }"
+          />
+          <div style="padding: 12px 16px">
             <MarkdownView
               :mode="mode"
               :source="(value as string) || '没有可预览的内容'"
@@ -336,6 +342,8 @@ watch([isWideScreen, () => props.sticky], () => nextTick(updateStickyToolbar));
   border-radius: 4px;
   overflow: hidden;
   background-color: var(--body-color);
+  position: relative;
+  z-index: 0;
 }
 
 .markdown-editor-boundary {
@@ -345,10 +353,22 @@ watch([isWideScreen, () => props.sticky], () => nextTick(updateStickyToolbar));
 .markdown-input .tabs .n-tabs-nav {
   --n-tab-gap: 0;
   background-color: var(--card-color);
-  margin: -1px 0 0 0;
-  border-top: 1px solid var(--border-color);
+  margin: 0;
+  border-top: none;
+  border-bottom: 1px solid var(--border-color);
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
+  box-sizing: border-box;
+  position: relative;
+  z-index: 2;
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+}
+
+.markdown-input .tabs .n-tabs-nav.is-fixed {
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .markdown-input .tabs .n-tabs-nav-scroll-wrapper {
@@ -357,6 +377,22 @@ watch([isWideScreen, () => props.sticky], () => nextTick(updateStickyToolbar));
 
 .markdown-input .tabs .n-tabs-nav__suffix {
   flex: 1 !important;
+  display: flex !important;
+  align-items: center !important;
+  height: 100% !important;
+  padding: 0 !important;
+  border-bottom: none !important;
+}
+
+/* On mobile views, unwrap suffix contents so jump buttons sit directly next to tabs on line 1, and line 2 wraps below */
+@media (max-width: 619px) {
+  .markdown-input .tabs .n-tabs-nav__suffix {
+    display: contents !important;
+  }
+}
+
+.markdown-input .tabs .n-tabs-nav__suffix::-webkit-scrollbar {
+  display: none !important;
 }
 
 .markdown-input .tabs .n-tabs-tab:not(.n-tabs-tab--active) {
@@ -371,30 +407,63 @@ watch([isWideScreen, () => props.sticky], () => nextTick(updateStickyToolbar));
   border-bottom-color: var(--body-color) !important;
 }
 
-.markdown-toolbar-host {
-  width: 100%;
-  min-height: 34px;
-}
-
 .markdown-toolbar-surface {
   box-sizing: border-box;
+  width: 100%;
+  height: 100%;
   min-height: 34px;
+  display: flex;
+  align-items: center;
   background-color: var(--card-color) !important;
 }
 
-.markdown-toolbar-surface.is-fixed {
-  position: fixed;
+.mobile-jump-buttons {
+  display: flex;
+  align-items: center;
+  padding-left: 8px;
+  height: 34px;
+}
+
+.mobile-toolbar-line2 {
+  width: 100%;
+  overflow-x: auto;
+  border-top: 1px solid var(--border-color);
+  padding: 4px 8px;
+  box-sizing: border-box;
+  background-color: var(--card-color);
+  scrollbar-width: none;
+}
+
+.mobile-toolbar-line2::-webkit-scrollbar {
+  display: none;
+}
+
+.toolbar-placeholder {
+  width: 100%;
+  flex-shrink: 0;
+}
+
+.editor-input-wrapper {
+  padding: 8px;
+  position: relative;
   z-index: 1;
 }
 
-.mobile-toolbar-host {
-  min-height: 42px;
+/* 避免 textarea 焦点边框高亮穿透到 toolbar 上方 */
+.editor-input-wrapper .n-input {
+  background-color: var(--body-color);
 }
 
-.mobile-toolbar {
-  min-height: 42px;
-  background-color: var(--body-color) !important;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--border-color);
+.editor-input-wrapper .n-input .n-input-wrapper {
+  z-index: 1;
+}
+
+.editor-input-wrapper .n-input.n-input--focus {
+  z-index: 1;
+}
+
+.editor-input-wrapper .n-input .n-input__border,
+.editor-input-wrapper .n-input .n-input__state-border {
+  z-index: 1;
 }
 </style>


### PR DESCRIPTION
1. 編輯/預覽 與 跳轉按鈕並列，能夠跟隨 sticky
2. 避免手機端進入sticky時跳動 (用於占位子)
3. 修正 桌面端 網頁按鈕在 y軸 沒有置中
4. 修正 textarea 的邊框高亮穿透到 toolbar 上方

<img width="456" height="422" alt="image" src="https://github.com/user-attachments/assets/174bef45-93bc-4238-8ee1-803381e1ec2d" />
