### PR TITLE
fix(web): 修復小說簡介拖曳選取，觸發展開而清除選取

### DIFF
--- a/web/src/pages/novel/components/WebNovelIntroduction.vue
+++ b/web/src/pages/novel/components/WebNovelIntroduction.vue
@@ -23,8 +23,29 @@ const displayedIntroduction = computed(() => {
   return props.introductionZh;
 });
 
-const toggleTranslation = () => {
+let downX = 0;
+let downY = 0;
+
+const onMouseDown = (e: MouseEvent) => {
+  downX = e.clientX;
+  downY = e.clientY;
+};
+
+const toggleTranslation = (e: MouseEvent) => {
   if (!hasTranslation.value) return;
+
+  const selection = window.getSelection();
+  if (selection && selection.toString().length > 0) {
+    return;
+  }
+
+  // 如果按下和抬起的位置相差较大，也视为拖拽选字
+  const dx = Math.abs(e.clientX - downX);
+  const dy = Math.abs(e.clientY - downY);
+  if (dx > 4 || dy > 4) {
+    return;
+  }
+
   expanded.value = !expanded.value;
 };
 </script>
@@ -38,6 +59,7 @@ const toggleTranslation = () => {
       WebkitLineClamp: !expanded && hasTranslation ? 5 : undefined,
       overflow: !expanded && hasTranslation ? 'hidden' : undefined,
     }"
+    @mousedown="onMouseDown"
     @click="toggleTranslation"
   >
     <template v-if="displayedIntroduction">


### PR DESCRIPTION
#400 
- 檢查選取長度，如果有: 不展開簡介
- mousedown 時 紀錄座標，判斷拖曳前後座標差異，差過小(無選取): 展開簡介