### PR TITLE
refactor(web)-重構web/文庫小說頁面底部為分頁格式，將"評論"、"術語表"、"文庫目錄"統整為分頁

### DIFF
--- a/web/src/components/NovelGlossaryEditor.vue
+++ b/web/src/components/NovelGlossaryEditor.vue
@@ -1,0 +1,289 @@
+<script lang="ts" setup>
+import { DeleteOutlineOutlined } from '@vicons/material';
+
+import { WebNovelApi, WenkuNovelApi } from '@/api';
+import { GenericNovelId } from '@/model/Common';
+import { Glossary } from '@/model/Glossary';
+import { copyToClipBoard, doAction } from '@/pages/util';
+import { useLocalVolumeStore, useWhoamiStore } from '@/stores';
+import { downloadFile } from '@/util';
+
+const props = defineProps<{
+  gnid?: GenericNovelId;
+  value: Glossary;
+}>();
+
+const message = useMessage();
+
+const whoamiStore = useWhoamiStore();
+const { whoami } = storeToRefs(whoamiStore);
+
+const glossary = ref<Glossary>({});
+const originalGlossary = ref<Glossary>({});
+
+const resetState = () => {
+  glossary.value = { ...props.value };
+  originalGlossary.value = { ...props.value };
+};
+
+onMounted(() => {
+  resetState();
+});
+
+watch(
+  () => props.value,
+  () => {
+    resetState();
+  },
+  { deep: true },
+);
+
+const isGlossaryChanged = () => {
+  const cur = glossary.value;
+  const orig = originalGlossary.value;
+  const curKeys = Object.keys(cur);
+  if (curKeys.length !== Object.keys(orig).length) return true;
+  return curKeys.some((key) => cur[key] !== orig[key]);
+};
+
+const gnidHint = computed(() => {
+  const gnid = props.gnid;
+  if (gnid === undefined) {
+    return undefined;
+  } else {
+    return GenericNovelId.toString(gnid);
+  }
+});
+
+const updateGlossary = async (glossaryValue: Glossary) => {
+  const gnid = props.gnid;
+  if (gnid === undefined) {
+    return;
+  }
+  if (gnid.type === 'web') {
+    await WebNovelApi.updateGlossary(
+      gnid.providerId,
+      gnid.novelId,
+      glossaryValue,
+    );
+  } else if (gnid.type === 'wenku') {
+    await WenkuNovelApi.updateGlossary(gnid.novelId, glossaryValue);
+  } else {
+    const repo = await useLocalVolumeStore();
+    await repo.updateGlossary(gnid.volumeId, glossaryValue);
+  }
+};
+
+const submitGlossary = () => {
+  const submittedGlossary = { ...toRaw(glossary.value) };
+  return doAction(
+    updateGlossary(submittedGlossary).then(() => {
+      for (const key in props.value) {
+        delete props.value[key];
+      }
+      for (const key in submittedGlossary) {
+        props.value[key] = submittedGlossary[key];
+      }
+      originalGlossary.value = { ...submittedGlossary };
+    }),
+    '术语表提交',
+    message,
+  );
+};
+
+const importGlossaryRaw = ref('');
+const termsToAdd = ref<[string, string]>(['', '']);
+
+const deletedTerms = ref<[string, string][]>([]);
+
+const lastDeletedTerm = computed(() => {
+  const last = deletedTerms.value[deletedTerms.value.length - 1];
+  if (last === undefined) return undefined;
+  return `${last[0]} => ${last[1]}`;
+});
+
+const clearTerm = () => {
+  glossary.value = {};
+};
+
+const undoDeleteTerm = () => {
+  if (deletedTerms.value.length === 0) return;
+  const [jp, zh] = deletedTerms.value.pop()!;
+  glossary.value[jp] = zh;
+};
+
+const deleteTerm = (jp: string) => {
+  if (jp in glossary.value) {
+    deletedTerms.value.push([jp, glossary.value[jp]]);
+    delete glossary.value[jp];
+  }
+};
+
+const addTerm = () => {
+  const [jp, zh] = termsToAdd.value;
+  if (jp && zh) {
+    glossary.value[jp.trim()] = zh.trim();
+    termsToAdd.value = ['', ''];
+  }
+};
+
+const exportGlossary = async (ev: MouseEvent) => {
+  const isSuccess = await copyToClipBoard(
+    Glossary.toText(glossary.value),
+    ev.target as HTMLElement,
+  );
+  if (isSuccess) {
+    message.success('导出成功：已复制到剪贴板');
+  } else {
+    message.success('导出失败');
+  }
+};
+
+const importGlossary = () => {
+  const importedGlossary = Glossary.fromText(importGlossaryRaw.value);
+  if (importedGlossary === undefined) {
+    message.error('导入失败：术语表格式不正确');
+  } else {
+    message.success('导入成功');
+    for (const jp in importedGlossary) {
+      const zh = importedGlossary[jp];
+      glossary.value[jp] = zh;
+    }
+  }
+};
+
+const downloadGlossaryAsJsonFile = async () => {
+  downloadFile(
+    `${gnidHint.value ?? 'glossary'}.json`,
+    new Blob([Glossary.toJson(glossary.value)], {
+      type: 'text/plain',
+    }),
+  );
+};
+
+defineExpose({
+  isGlossaryChanged,
+  resetState,
+});
+</script>
+
+<template>
+  <div class="novel-glossary-editor">
+    <n-flex vertical size="large" style="max-width: 500px; margin-bottom: 16px">
+      <n-h3 prefix="bar">编辑术语表</n-h3>
+      <template v-if="gnidHint">
+        <n-text style="font-size: 12px">{{ gnidHint }}</n-text>
+
+        <n-text>
+          使用前务必先阅读
+          <c-a to="/forum/660ab4da55001f583649a621">术语表使用指南</c-a>
+          ，不要滥用术语表。
+        </n-text>
+      </template>
+
+      <n-input-group>
+        <n-input
+          pair
+          v-model:value="termsToAdd"
+          size="small"
+          separator="=>"
+          :placeholder="['日文', '中文']"
+          :input-props="{ spellcheck: false }"
+        />
+        <c-button label="添加" :round="false" size="small" @action="addTerm" />
+      </n-input-group>
+
+      <n-input
+        v-model:value="importGlossaryRaw"
+        type="textarea"
+        size="small"
+        placeholder="批量导入术语表"
+        :input-props="{ spellcheck: false }"
+        :rows="1"
+      />
+
+      <n-flex align="center" :wrap="false">
+        <c-button
+          label="导出"
+          :round="false"
+          size="small"
+          @action="exportGlossary"
+        />
+        <c-button
+          label="导入"
+          :round="false"
+          size="small"
+          @action="importGlossary"
+        />
+        <c-button
+          label="下载json文件"
+          :round="false"
+          size="small"
+          @action="downloadGlossaryAsJsonFile"
+        />
+        <c-button
+          v-if="whoami.isAdmin"
+          secondary
+          type="error"
+          label="清空"
+          :round="false"
+          size="small"
+          @action="clearTerm"
+        />
+      </n-flex>
+
+      <n-flex align="center" :wrap="false">
+        <c-button
+          :disabled="deletedTerms.length === 0"
+          label="撤销删除"
+          :round="false"
+          size="small"
+          @action="undoDeleteTerm"
+        />
+        <n-text
+          v-if="lastDeletedTerm !== undefined"
+          depth="3"
+          style="font-size: 12px"
+        >
+          {{ lastDeletedTerm }}
+        </n-text>
+      </n-flex>
+    </n-flex>
+
+    <n-scrollbar
+      v-if="Object.keys(glossary).length !== 0"
+      style="max-height: 400px; max-width: 500px; margin-bottom: 16px"
+    >
+      <n-table striped size="small" style="font-size: 12px; width: 100%">
+        <tr v-for="wordJp in Object.keys(glossary).reverse()" :key="wordJp">
+          <td>
+            <c-button
+              :icon="DeleteOutlineOutlined"
+              text
+              type="error"
+              size="small"
+              @action="deleteTerm(wordJp)"
+            />
+          </td>
+          <td>{{ wordJp }}</td>
+          <td nowrap="nowrap">=></td>
+          <td style="padding-right: 16px">
+            <n-input
+              v-model:value="glossary[wordJp]"
+              size="tiny"
+              placeholder="请输入中文翻译"
+              :theme-overrides="{
+                border: '0',
+                color: 'transparent',
+              }"
+            />
+          </td>
+        </tr>
+      </n-table>
+    </n-scrollbar>
+
+    <n-flex justify="end" style="max-width: 500px">
+      <c-button label="提交" type="primary" @action="submitGlossary()" />
+    </n-flex>
+  </div>
+</template>

--- a/web/src/components/NovelGlossaryEditor.vue
+++ b/web/src/components/NovelGlossaryEditor.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { useEventListener } from '@vueuse/core';
+import { onBeforeRouteLeave } from 'vue-router';
 import { DeleteOutlineOutlined } from '@vicons/material';
 
 import { WebNovelApi, WenkuNovelApi } from '@/api';
@@ -12,6 +14,58 @@ const props = defineProps<{
   gnid?: GenericNovelId;
   value: Glossary;
 }>();
+
+const showConfirmModal = ref(false);
+const pendingConfirmResolve = ref<((value: boolean) => void) | null>(null);
+
+const cancelPendingNavigation = () => {
+  if (pendingConfirmResolve.value) {
+    pendingConfirmResolve.value(false);
+    pendingConfirmResolve.value = null;
+  }
+  showConfirmModal.value = false;
+};
+
+const handleConfirmClose = () => {
+  showConfirmModal.value = false;
+  if (pendingConfirmResolve.value) {
+    resetState();
+    pendingConfirmResolve.value(true);
+    pendingConfirmResolve.value = null;
+  }
+};
+
+const handleConfirmCancel = () => {
+  cancelPendingNavigation();
+};
+
+const handleModalUpdateShow = (show: boolean) => {
+  if (!show) {
+    cancelPendingNavigation();
+  }
+};
+
+const confirmLeave = () => {
+  if (isGlossaryChanged()) {
+    return new Promise<boolean>((resolve) => {
+      cancelPendingNavigation();
+      pendingConfirmResolve.value = resolve;
+      showConfirmModal.value = true;
+    });
+  }
+  return true;
+};
+
+onBeforeRouteLeave(() => {
+  return confirmLeave();
+});
+
+useEventListener(window, 'beforeunload', (e) => {
+  if (isGlossaryChanged()) {
+    e.preventDefault();
+    return '检测到未保存的修改，确认关闭吗？';
+  }
+});
 
 const message = useMessage();
 
@@ -164,6 +218,7 @@ const downloadGlossaryAsJsonFile = async () => {
 defineExpose({
   isGlossaryChanged,
   resetState,
+  confirmLeave,
 });
 </script>
 
@@ -285,5 +340,40 @@ defineExpose({
     <n-flex justify="end" style="max-width: 500px">
       <c-button label="提交" type="primary" @action="submitGlossary()" />
     </n-flex>
+
+    <n-modal
+      :show="showConfirmModal"
+      @update:show="handleModalUpdateShow"
+      preset="card"
+      title="提示"
+      :bordered="false"
+      size="small"
+      transform-origin="center"
+      style="
+        position: fixed;
+        top: 50px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: min(420px, calc(100% - 32px));
+      "
+    >
+      <n-text>检测到未保存的修改，确认关闭吗？</n-text>
+      <template #action>
+        <n-flex justify="end">
+          <c-button
+            label="确认"
+            type="warning"
+            size="small"
+            @action="handleConfirmClose"
+          />
+          <c-button
+            label="取消"
+            secondary
+            size="small"
+            @action="handleConfirmCancel"
+          />
+        </n-flex>
+      </template>
+    </n-modal>
   </div>
 </template>

--- a/web/src/pages/novel/WenkuNovel.vue
+++ b/web/src/pages/novel/WenkuNovel.vue
@@ -2,12 +2,13 @@
 import { EditNoteOutlined, LanguageOutlined } from '@vicons/material';
 import { createReusableTemplate } from '@vueuse/core';
 
-import { WenkuNovelRepo } from '@/repos';
 import coverPlaceholder from '@/image/cover_placeholder.png';
 import { GenericNovelId } from '@/model/Common';
-import { doAction, useIsWideScreen } from '@/pages/util';
-import { useSettingStore, useWhoamiStore } from '@/stores';
 import type { VolumeJpDto } from '@/model/WenkuNovel';
+import NovelBottomTabs from '@/pages/novel/components/NovelBottomTabs.vue';
+import { doAction, useIsWideScreen } from '@/pages/util';
+import { WenkuNovelRepo } from '@/repos';
+import { useSettingStore, useWhoamiStore } from '@/stores';
 
 const { novelId } = defineProps<{ novelId: string }>();
 
@@ -209,88 +210,85 @@ function sortJpVolumes(volumeJp: VolumeJpDto[]) {
         </c-x-scrollbar>
       </template>
 
-      <section-header title="目录" />
-      <template v-if="whoami.isSignedIn">
-        <upload-button :allow-zh="whoami.isAdmin" :novel-id="novelId" />
-
-        <TranslateOptions
-          ref="translateOptions"
-          :gnid="GenericNovelId.wenku(novelId)"
-          style="margin-top: 16px"
-        />
-        <n-flex style="margin-top: 16px">
-          <n-button-group>
-            <GlossaryButton
-              :gnid="GenericNovelId.wenku(novelId)"
-              :value="novel.glossary"
-              :round="false"
-            />
-            <DownloadOptionsButton :round="false" />
-          </n-button-group>
-        </n-flex>
-        <n-divider style="margin: 16px 0 0" />
-
-        <n-list>
-          <n-list-item
-            v-for="volume of sortJpVolumes(novel.volumeJp)"
-            :key="volume.volumeId"
-          >
-            <WenkuVolume
-              :novel-id="novelId"
-              :volume="volume"
-              :get-params="() => translateOptions!.getTranslateTaskParams()"
-              @delete="deleteVolume(volume.volumeId)"
-            />
-          </n-list-item>
-        </n-list>
-
-        <template v-if="whoami.isAdmin">
-          <n-divider style="margin: 0" />
-
-          <n-ul>
-            <n-li v-for="volumeId in novel.volumeZh" :key="volumeId">
-              <n-a
-                :href="`/files-wenku/${novelId}/${encodeURIComponent(volumeId)}`"
-                target="_blank"
-                :download="volumeId"
-              >
-                {{ volumeId }}
-              </n-a>
-
-              <c-button-confirm
-                v-if="whoami.asAdmin"
-                :hint="`真的要删除《${volumeId}》吗？`"
-                label="删除"
-                text
-                type="error"
-                style="margin-left: 16px"
-                @action="deleteVolume(volumeId)"
-              />
-            </n-li>
-          </n-ul>
-        </template>
-
-        <n-empty
-          v-if="novel.volumeJp.length === 0 && novel.volumeZh.length === 0"
-          description="请不要创建一个空页面"
-        />
-
-        <n-empty
-          v-if="
-            !whoami.isAdmin &&
-            novel.volumeJp.length === 0 &&
-            novel.volumeZh.length > 0
-          "
-          description="网站已撤下中文小说板块，请上传日文生成翻译"
-        />
-      </template>
-      <n-p v-else>游客无法查看内容，请先登录。</n-p>
-
-      <comment-list
-        v-if="!setting.hideCommmentWenkuNovel"
+      <NovelBottomTabs
+        :gnid="GenericNovelId.wenku(novelId)"
+        :glossary="novel.glossary"
         :site="`wenku-${novelId}`"
+        :hide-comment="setting.hideCommmentWenkuNovel"
         :locked="false"
-      />
+      >
+        <template #wenkuToc>
+          <template v-if="whoami.isSignedIn">
+            <br />
+            <upload-button :allow-zh="whoami.isAdmin" :novel-id="novelId" />
+
+            <TranslateOptions
+              ref="translateOptions"
+              :gnid="GenericNovelId.wenku(novelId)"
+              style="margin-top: 16px"
+            />
+            <n-flex style="margin-top: 16px">
+              <DownloadOptionsButton :round="false" />
+            </n-flex>
+            <n-divider style="margin: 16px 0 0" />
+
+            <n-list>
+              <n-list-item
+                v-for="volume of sortJpVolumes(novel.volumeJp)"
+                :key="volume.volumeId"
+              >
+                <WenkuVolume
+                  :novel-id="novelId"
+                  :volume="volume"
+                  :get-params="() => translateOptions!.getTranslateTaskParams()"
+                  @delete="deleteVolume(volume.volumeId)"
+                />
+              </n-list-item>
+            </n-list>
+
+            <template v-if="whoami.isAdmin">
+              <n-divider style="margin: 0" />
+
+              <n-ul>
+                <n-li v-for="volumeId in novel.volumeZh" :key="volumeId">
+                  <n-a
+                    :href="`/files-wenku/${novelId}/${encodeURIComponent(volumeId)}`"
+                    target="_blank"
+                    :download="volumeId"
+                  >
+                    {{ volumeId }}
+                  </n-a>
+
+                  <c-button-confirm
+                    v-if="whoami.asAdmin"
+                    :hint="`真的要删除《${volumeId}》吗？`"
+                    label="删除"
+                    text
+                    type="error"
+                    style="margin-left: 16px"
+                    @action="deleteVolume(volumeId)"
+                  />
+                </n-li>
+              </n-ul>
+            </template>
+
+            <n-empty
+              v-if="novel.volumeJp.length === 0 && novel.volumeZh.length === 0"
+              description="请不要创建一个空页面"
+            />
+
+            <n-empty
+              v-if="
+                !whoami.isAdmin &&
+                novel.volumeJp.length === 0 &&
+                novel.volumeZh.length > 0
+              "
+              description="网站已撤下中文小说板块，请上传日文生成翻译"
+            />
+          </template>
+          <n-p v-else>游客无法查看内容，请先登录。</n-p>
+        </template>
+      </NovelBottomTabs>
     </template>
 
     <CResultX v-else :error="error" title="加载错误" />

--- a/web/src/pages/novel/components/NovelBottomTabs.vue
+++ b/web/src/pages/novel/components/NovelBottomTabs.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { useEventListener } from '@vueuse/core';
+
 import NovelGlossaryEditor from '@/components/NovelGlossaryEditor.vue';
 import type { GenericNovelId } from '@/model/Common';
 import type { Glossary } from '@/model/Glossary';
@@ -27,11 +29,26 @@ watch(
 );
 
 const glossaryCount = computed(() => Object.keys(props.glossary).length);
+
+const editorRef =
+  useTemplateRef<InstanceType<typeof NovelGlossaryEditor>>('editorRef');
+
+const handleBeforeLeave = (name: string, oldName: string) => {
+  if (oldName === 'glossary' && editorRef.value) {
+    return editorRef.value.confirmLeave();
+  }
+  return true;
+};
 </script>
 
 <template>
   <div class="novel-bottom-tabs" style="margin-top: 24px">
-    <n-tabs v-model:value="activeTab" type="line" animated>
+    <n-tabs
+      v-model:value="activeTab"
+      type="line"
+      animated
+      :on-before-leave="handleBeforeLeave"
+    >
       <n-tab-pane
         v-if="$slots.wenkuToc"
         name="wenkuToc"
@@ -55,7 +72,7 @@ const glossaryCount = computed(() => Object.keys(props.glossary).length);
         :tab="`术语表${glossaryCount > 0 ? ` [${glossaryCount}]` : ''}`"
         style="min-height: 400px"
       >
-        <NovelGlossaryEditor :gnid="gnid" :value="glossary" />
+        <NovelGlossaryEditor ref="editorRef" :gnid="gnid" :value="glossary" />
       </n-tab-pane>
     </n-tabs>
   </div>

--- a/web/src/pages/novel/components/NovelBottomTabs.vue
+++ b/web/src/pages/novel/components/NovelBottomTabs.vue
@@ -1,0 +1,62 @@
+<script lang="ts" setup>
+import NovelGlossaryEditor from '@/components/NovelGlossaryEditor.vue';
+import type { GenericNovelId } from '@/model/Common';
+import type { Glossary } from '@/model/Glossary';
+
+const props = defineProps<{
+  gnid?: GenericNovelId;
+  glossary: Glossary;
+  site: string;
+  hideComment: boolean;
+  locked?: boolean;
+}>();
+
+const slots = useSlots();
+
+const activeTab = ref(
+  slots.wenkuToc ? 'wenkuToc' : props.hideComment ? 'glossary' : 'comment',
+);
+
+watch(
+  () => props.hideComment,
+  (hide) => {
+    if (hide && activeTab.value === 'comment') {
+      activeTab.value = 'glossary';
+    }
+  },
+);
+
+const glossaryCount = computed(() => Object.keys(props.glossary).length);
+</script>
+
+<template>
+  <div class="novel-bottom-tabs" style="margin-top: 24px">
+    <n-tabs v-model:value="activeTab" type="line" animated>
+      <n-tab-pane
+        v-if="$slots.wenkuToc"
+        name="wenkuToc"
+        tab="目录"
+        style="min-height: 400px"
+      >
+        <slot name="wenkuToc" />
+      </n-tab-pane>
+
+      <n-tab-pane
+        v-if="!hideComment"
+        name="comment"
+        tab="评论区"
+        style="min-height: 400px"
+      >
+        <comment-list :site="site" :locked="locked ?? false" />
+      </n-tab-pane>
+
+      <n-tab-pane
+        name="glossary"
+        :tab="`术语表${glossaryCount > 0 ? ` [${glossaryCount}]` : ''}`"
+        style="min-height: 400px"
+      >
+        <NovelGlossaryEditor :gnid="gnid" :value="glossary" />
+      </n-tab-pane>
+    </n-tabs>
+  </div>
+</template>

--- a/web/src/pages/novel/components/NovelBottomTabs.vue
+++ b/web/src/pages/novel/components/NovelBottomTabs.vue
@@ -39,6 +39,46 @@ const handleBeforeLeave = (name: string, oldName: string) => {
   }
   return true;
 };
+
+const availableTabs = computed(() => {
+  const tabs: string[] = [];
+  if (slots.wenkuToc) tabs.push('wenkuToc');
+  if (!props.hideComment) tabs.push('comment');
+  tabs.push('glossary');
+  return tabs;
+});
+
+const switchTab = async (targetTab: string) => {
+  if (targetTab === activeTab.value) return;
+  const allow = await handleBeforeLeave(targetTab, activeTab.value);
+  if (allow) {
+    activeTab.value = targetTab;
+  }
+};
+
+useEventListener(window, 'keydown', (e: KeyboardEvent) => {
+  if (e.isComposing || e.ctrlKey || e.altKey || e.metaKey) return;
+
+  const target = e.target as HTMLElement | null;
+  if (
+    target &&
+    (target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.tagName === 'SELECT' ||
+      target.isContentEditable)
+  ) {
+    return;
+  }
+
+  if (/^[0-9]$/.test(e.key)) {
+    const index = e.key === '0' ? 9 : Number(e.key) - 1;
+    const targetTab = availableTabs.value[index];
+    if (targetTab) {
+      e.preventDefault();
+      switchTab(targetTab);
+    }
+  }
+});
 </script>
 
 <template>

--- a/web/src/pages/novel/components/WebNovelNarrow.vue
+++ b/web/src/pages/novel/components/WebNovelNarrow.vue
@@ -6,7 +6,9 @@ import {
 } from '@vicons/material';
 import { NScrollbar } from 'naive-ui';
 
+import { GenericNovelId } from '@/model/Common';
 import type { WebNovelDto, WebNovelTocItemDto } from '@/model/WebNovel';
+import NovelBottomTabs from '@/pages/novel/components/NovelBottomTabs.vue';
 import { useSettingStore } from '@/stores';
 import { useTocExpansion } from './UseTocExpansion';
 import { useLastReadChapter, useToc } from './UseWebNovel';
@@ -195,9 +197,11 @@ const { expandedNames, hasSeparators, isAnyExpanded, toggleAll, tocSections } =
     </div>
   </c-drawer-right>
 
-  <comment-list
-    v-if="!setting.hideCommmentWebNovel"
+  <NovelBottomTabs
+    :gnid="GenericNovelId.web(providerId, novelId)"
+    :glossary="novel.glossary"
     :site="`web-${providerId}-${novelId}`"
+    :hide-comment="setting.hideCommmentWebNovel"
     :locked="false"
   />
 </template>

--- a/web/src/pages/novel/components/WebNovelWide.vue
+++ b/web/src/pages/novel/components/WebNovelWide.vue
@@ -6,7 +6,9 @@ import {
 } from '@vicons/material';
 import { NScrollbar } from 'naive-ui';
 
+import { GenericNovelId } from '@/model/Common';
 import type { WebNovelDto, WebNovelTocItemDto } from '@/model/WebNovel';
+import NovelBottomTabs from '@/pages/novel/components/NovelBottomTabs.vue';
 import { useSettingStore } from '@/stores';
 import { useTocExpansion } from './UseTocExpansion';
 import { useLastReadChapter, useToc } from './UseWebNovel';
@@ -58,9 +60,11 @@ const { expandedNames, hasSeparators, isAnyExpanded, toggleAll, tocSections } =
       :glossary="novel.glossary"
     />
 
-    <comment-list
-      v-if="!setting.hideCommmentWebNovel"
+    <NovelBottomTabs
+      :gnid="GenericNovelId.web(providerId, novelId)"
+      :glossary="novel.glossary"
       :site="`web-${providerId}-${novelId}`"
+      :hide-comment="setting.hideCommmentWebNovel"
       :locked="false"
     />
 

--- a/web/src/pages/novel/components/WebTranslate.vue
+++ b/web/src/pages/novel/components/WebTranslate.vue
@@ -202,14 +202,7 @@ const submitJob = (id: 'gpt' | 'sakura') => {
     v-if="whoami.isSignedIn && setting.enabledTranslator.length > 0"
     style="margin-top: 16px"
   >
-    <n-button-group>
-      <GlossaryButton
-        :gnid="GenericNovelId.web(providerId, novelId)"
-        :value="glossary"
-        :round="false"
-      />
-      <c-button label="导入工作区" :round="false" @action="importToWorkspace" />
-    </n-button-group>
+    <c-button label="导入工作区" :round="false" @action="importToWorkspace" />
 
     <n-button-group>
       <c-button


### PR DESCRIPTION
因應未來可能模塊增加，或術語表modal過於臃腫，將"評論"、"術語表"、文庫的 "目錄" 遷移至重構的分頁結構

### Notice
- 保留了 GlossaryButton.vue

## web小說
<img width="874" height="189" alt="image" src="https://github.com/user-attachments/assets/74b129b9-ed61-4731-aad3-6e5854f68c14" />

---

## 文庫小說
<img width="1340" height="818" alt="image" src="https://github.com/user-attachments/assets/fccaa75a-3299-47fa-b191-f7ddd3546356" />
