### PR TITLE
feat(web): Sakura Pipeline 工作区

### DIFF
--- a/packages/translator/src/pipeline/translation_pipeline.ts
+++ b/packages/translator/src/pipeline/translation_pipeline.ts
@@ -29,7 +29,7 @@ export class TranslationPipeline {
     highWaterMark?: number,
     segmenter?: LineSegmenter,
     cache?: SegmentCache,
-    private readonly concurrencyLevel: 'segment' | 'chapter' = 'segment', // 为 chapter 时，传入的章节按分段顺序依次翻译（而非全部并发），同时填充前个分段的译文
+    private readonly concurrencyLevel: 'segment' | 'chapter' = 'segment', // 为 chapter 时，传入的章节按分段顺序依次翻译，同时填充前个分段的译文
   ) {
     this.translatorLoops = new Map();
     this.queue = new DefaultSegmentQueue(highWaterMark ?? 50);
@@ -79,10 +79,15 @@ export class TranslationPipeline {
     const deferredMap = new Map<number, Deferred>();
 
     const onSegStart = (segment: Segment, translatorId: string) => {
-      tracker?.onSegStart?.(segment.order, translatorId);
+      if (!signal?.aborted) {
+        tracker?.onSegStart?.(segment.order, translatorId);
+      }
     };
 
+    const prevSegs: string[][] | undefined =
+      this.concurrencyLevel === 'chapter' ? [] : undefined;
     const onSegComplete = (segment: Segment, translatedLines: string[]) => {
+      prevSegs?.push(translatedLines);
       deferredMap.get(segment.order)?.resolve({
         order: segment.order,
         text: translatedLines.join('\n'),
@@ -93,8 +98,21 @@ export class TranslationPipeline {
     };
 
     const onSegError = (segment: Segment, reason: any) => {
-      tracker?.onSegError?.(segment.order, reason);
+      if (!signal?.aborted) {
+        tracker?.onSegError?.(segment.order, reason);
+      }
       deferredMap.get(segment.order)?.reject(reason);
+      if (this.concurrencyLevel === 'chapter') {
+        // 章节并发模式，单个分片失败，后续自动失败
+        for (const seg of segments) {
+          if (seg.order > segment.order) {
+            deferredMap.get(seg.order)?.reject(reason);
+            if (!signal?.aborted) {
+              tracker?.onSegError?.(seg.order, reason);
+            }
+          }
+        }
+      }
     };
 
     const segments = this.assembler.assemble(
@@ -107,6 +125,14 @@ export class TranslationPipeline {
       onSegError,
       history,
     );
+
+    if (this.concurrencyLevel === 'chapter') {
+      for (const [index, segment] of segments.entries()) {
+        segment.context = { ...segment.context, prevSegs };
+        segment.next = () =>
+          signal?.aborted ? undefined : segments[index + 1];
+      }
+    }
 
     const segmentPromises: Promise<{ order: number; text: string }>[] = [];
     for (const seg of segments) {
@@ -138,30 +164,13 @@ export class TranslationPipeline {
     signal?: AbortSignal,
     tracker?: SegmentTracker,
   ): Promise<string> {
+    const resultsPromise = Promise.allSettled(segmentPromises);
     if (this.concurrencyLevel === 'segment') {
       await this.queue.enqueueAll(segments, signal);
-    } else {
-      const prevSegs: string[][] = [];
-      // 逐分片确认翻译完成
-      for (const [index, segment] of segments.entries()) {
-        segment.context = {
-          ...segment.context,
-          prevSegs: prevSegs,
-        };
-
-        await this.queue.enqueueAll([segment], signal);
-
-        const [result] = await Promise.allSettled([segmentPromises[index]]);
-
-        if (signal?.aborted) break;
-
-        if (result.status === 'fulfilled') {
-          prevSegs.push(result.value.text.split('\n'));
-        }
-      }
+    } else if (this.concurrencyLevel === 'chapter' && segments.length > 0) {
+      await this.queue.enqueueAll([segments[0]], signal);
     }
-
-    const results = await Promise.allSettled(segmentPromises);
+    const results = await resultsPromise;
 
     if (signal?.aborted) {
       tracker?.onAbort?.();
@@ -228,7 +237,7 @@ export class TranslationPipeline {
         segment.onComplete(segment, segment.context.history.translatedLines);
         return;
       }
-      if (loop.abortController.signal.aborted) return;
+      loop.abortController.signal.throwIfAborted();
       segment.onStart(segment, loop.id);
       const translatedLines = await loop.translator.translate(
         segment.lines,
@@ -249,13 +258,19 @@ export class TranslationPipeline {
           .then((segment) => {
             updateConcurrency(1);
             processSegment(segment)
+              .then(() => {
+                this.queue.ack(segment.next?.());
+              })
               .catch((err: any) => {
-                if (err.name !== 'AbortError') {
+                if (
+                  err.name !== 'AbortError' ||
+                  this.concurrencyLevel === 'chapter'
+                ) {
                   segment.onError(segment, err);
                 }
+                this.queue.ack();
               })
               .finally(() => {
-                this.queue.ack();
                 semaphore.release();
                 updateConcurrency(-1);
               });

--- a/packages/translator/src/pipeline/translation_pipeline.ts
+++ b/packages/translator/src/pipeline/translation_pipeline.ts
@@ -29,6 +29,7 @@ export class TranslationPipeline {
     highWaterMark?: number,
     segmenter?: LineSegmenter,
     cache?: SegmentCache,
+    private readonly concurrencyLevel: 'segment' | 'chapter' = 'segment', // 为 chapter 时，传入的章节按分段顺序依次翻译（而非全部并发），同时填充前个分段的译文
   ) {
     this.translatorLoops = new Map();
     this.queue = new DefaultSegmentQueue(highWaterMark ?? 50);
@@ -51,7 +52,6 @@ export class TranslationPipeline {
       signal,
       tracker,
     );
-    await this.queue.enqueueAll(segments, signal);
     return this.resolveTranslation(segments, segmentPromises, signal, tracker);
   }
 
@@ -138,6 +138,29 @@ export class TranslationPipeline {
     signal?: AbortSignal,
     tracker?: SegmentTracker,
   ): Promise<string> {
+    if (this.concurrencyLevel === 'segment') {
+      await this.queue.enqueueAll(segments, signal);
+    } else {
+      const prevSegs: string[][] = [];
+      // 逐分片确认翻译完成
+      for (const [index, segment] of segments.entries()) {
+        segment.context = {
+          ...segment.context,
+          prevSegs: prevSegs,
+        };
+
+        await this.queue.enqueueAll([segment], signal);
+
+        const [result] = await Promise.allSettled([segmentPromises[index]]);
+
+        if (signal?.aborted) break;
+
+        if (result.status === 'fulfilled') {
+          prevSegs.push(result.value.text.split('\n'));
+        }
+      }
+    }
+
     const results = await Promise.allSettled(segmentPromises);
 
     if (signal?.aborted) {

--- a/packages/translator/src/segment/segment_queue.ts
+++ b/packages/translator/src/segment/segment_queue.ts
@@ -97,8 +97,20 @@ export class DefaultSegmentQueue implements SegmentQueue {
     });
   }
 
-  /** 消费者完成一个分片后调用，释放一个槽位 */
-  ack(): void {
+  /**
+   * 消费者完成一个分片后调用，释放一个槽位
+   * 如果提供了next，将next中的分片排入队首（顺序执行的分片链表）
+   * */
+  ack(next?: Segment): void {
+    if (next) {
+      const resolve = this._dequeueResolvers.shift();
+      if (resolve) {
+        resolve(next);
+      } else {
+        this._items.unshift(next);
+      }
+      return;
+    }
     this._enqueuedCount--;
     this._tryResolveHw();
   }
@@ -112,5 +124,13 @@ export class DefaultSegmentQueue implements SegmentQueue {
       const resolve = this._hwResolvers.shift()!;
       resolve();
     }
+  }
+
+  clear(): void {
+    this._enqueuedCount -= this._items.length;
+    this._items.length = 0;
+    const hw = this._hwResolvers.splice(0);
+    for (const resolve of hw) resolve();
+    this._dequeueResolvers.splice(0);
   }
 }

--- a/packages/translator/src/types.ts
+++ b/packages/translator/src/types.ts
@@ -19,6 +19,7 @@ export interface Segment {
   onStart: (segment: Segment, translatorId: string) => void;
   onComplete: (segment: Segment, translatedLines: string[]) => void;
   onError: (segment: Segment, reason: any) => void;
+  next?: () => Segment | undefined;
 }
 
 /**
@@ -61,7 +62,8 @@ export abstract class SegmentQueue {
   abstract enqueueAll(segments: Segment[], signal?: AbortSignal): Promise<void>;
   abstract dequeue(signal?: AbortSignal): Promise<Segment>;
   abstract waitUntilBelowHighWaterMark(signal?: AbortSignal): Promise<void>;
-  abstract ack(): void;
+  abstract ack(next?: Segment): void;
+  abstract clear(): void;
 }
 
 export interface PromptBuilder {

--- a/web/src/domain/translator/IndexedDbSegmentCache.ts
+++ b/web/src/domain/translator/IndexedDbSegmentCache.ts
@@ -3,7 +3,7 @@ import type { Segment, SegmentCache } from '@auto-novel/translator';
 import { TranslationCacheRepo } from '@/repos';
 
 export class IndexedDbSegmentCache implements SegmentCache {
-  constructor(private storeName: 'gpt-seg-cache' = 'gpt-seg-cache') {}
+  constructor(private storeName: 'gpt-seg-cache' | 'sakura-seg-cache') {}
 
   async get(segment: Segment): Promise<string[] | undefined> {
     const key = this.computeKey(segment);

--- a/web/src/domain/translator/TaskExecutor.ts
+++ b/web/src/domain/translator/TaskExecutor.ts
@@ -14,6 +14,7 @@ export class TaskExecutor {
     private task: TranslationTask,
     private pipeline: TranslationPipeline,
     private fetchSemaphore: Semaphore,
+    private canUpload?: () => boolean,
   ) {}
 
   /**
@@ -35,6 +36,9 @@ export class TaskExecutor {
     tracker.onLog(`[${chapter.title}] 开始获取原文`);
 
     try {
+      if (this.task.type !== 'local' && this.canUpload?.() === false) {
+        throw new Error('存在未通过上传检查的翻译器，无法启动网络／文库任务');
+      }
       const fetchAndPrepare = async () => {
         await this.pipeline.waitUntilBelowHighWaterMark(signal);
         const detail = await this.task.fetchChapter(chapterId);

--- a/web/src/domain/translator/TaskExecutor.ts
+++ b/web/src/domain/translator/TaskExecutor.ts
@@ -35,7 +35,7 @@ export class TaskExecutor {
     tracker.onLog(`[${chapter.title}] 开始获取原文`);
 
     try {
-      const fetchAndEnqueue = async () => {
+      const fetchAndPrepare = async () => {
         await this.pipeline.waitUntilBelowHighWaterMark(signal);
         const detail = await this.task.fetchChapter(chapterId);
 
@@ -55,15 +55,14 @@ export class TaskExecutor {
           signal,
           tracker.segmentTracker,
         );
-        await this.pipeline.queue.enqueueAll(segments, signal);
         tracker.onChapterStatus(chapterId, 'translating');
         tracker.onLog(`[${chapter.title}] 开始翻译`);
 
         return { detail, segments, segmentPromises };
       };
       const { detail, segments, segmentPromises } = this.fetchSemaphore
-        ? await this.fetchSemaphore.use(fetchAndEnqueue)
-        : await fetchAndEnqueue();
+        ? await this.fetchSemaphore.use(fetchAndPrepare)
+        : await fetchAndPrepare();
 
       const translated = await this.pipeline.resolveTranslation(
         segments,

--- a/web/src/domain/translator/TranslationTask/LocalTranslationTask.ts
+++ b/web/src/domain/translator/TranslationTask/LocalTranslationTask.ts
@@ -2,7 +2,7 @@ import type { Glossary } from '@auto-novel/translator';
 import type { ChapterMeta } from '../TaskState';
 import type { TranslateTaskParams } from '@/model/Translator';
 import type { LocalVolumeMetadata } from '@/model/LocalVolume';
-import type { ChapterDetail, TranslationTask } from './types';
+import type { ChapterDetail, TranslationTask, TranslatorId } from './types';
 import type { LocalVolumeStore } from '@/stores/local/LocalVolumeRepository';
 import { useLocalVolumeStore } from '@/stores';
 import { buildChapterMetaList } from './utils';
@@ -20,7 +20,7 @@ export class LocalTranslationTask implements TranslationTask {
 
   constructor(
     private volumeId: string,
-    private translatorId: 'gpt',
+    private translatorId: TranslatorId,
     private params: TranslateTaskParams,
   ) {
     this.description = `local/${volumeId}`;

--- a/web/src/domain/translator/TranslationTask/WebTranslationTask.ts
+++ b/web/src/domain/translator/TranslationTask/WebTranslationTask.ts
@@ -1,7 +1,7 @@
 import type { Glossary } from '@auto-novel/translator';
 import type { ChapterMeta } from '../TaskState';
 import type { TranslateTaskParams, WebTranslateTask } from '@/model/Translator';
-import type { ChapterDetail, TranslationTask } from './types';
+import type { ChapterDetail, TranslationTask, TranslatorId } from './types';
 import { WebNovelApi } from '@/api';
 import { buildChapterMetaList } from './utils';
 
@@ -20,7 +20,7 @@ export class WebTranslationTask implements TranslationTask {
   constructor(
     private providerId: string,
     private novelId: string,
-    private translatorId: 'gpt',
+    private translatorId: TranslatorId,
     params: TranslateTaskParams,
   ) {
     this.description = `web/${providerId}/${novelId}`;

--- a/web/src/domain/translator/TranslationTask/WenkuTranslationTask.ts
+++ b/web/src/domain/translator/TranslationTask/WenkuTranslationTask.ts
@@ -1,11 +1,10 @@
 import type { Glossary } from '@auto-novel/translator';
 import type { ChapterMeta } from '../TaskState';
 import type {
-  TranslatorId,
   TranslateTaskParams,
   WenkuTranslateTask,
 } from '@/model/Translator';
-import type { ChapterDetail, TranslationTask } from './types';
+import type { ChapterDetail, TranslationTask, TranslatorId } from './types';
 import { WenkuNovelApi } from '@/api';
 import { buildChapterMetaList } from './utils';
 
@@ -24,7 +23,7 @@ export class WenkuTranslationTask implements TranslationTask {
   constructor(
     private novelId: string,
     private volumeId: string,
-    private translatorId: 'gpt',
+    private translatorId: TranslatorId,
     params: TranslateTaskParams,
   ) {
     this.description = `wenku/${novelId}/${volumeId}`;

--- a/web/src/domain/translator/TranslationTask/createTranslationTask.ts
+++ b/web/src/domain/translator/TranslationTask/createTranslationTask.ts
@@ -2,14 +2,14 @@ import type {
   TranslateTaskDesc,
   TranslateTaskParams,
 } from '@/model/Translator';
-import type { TranslationTask } from './types';
+import type { TranslationTask, TranslatorId } from './types';
 import { LocalTranslationTask } from './LocalTranslationTask';
 import { WebTranslationTask } from './WebTranslationTask';
 import { WenkuTranslationTask } from './WenkuTranslationTask';
 
 export function createTranslationTask(
   desc: TranslateTaskDesc,
-  translatorId: 'gpt',
+  translatorId: TranslatorId,
   params: TranslateTaskParams,
 ): TranslationTask {
   switch (desc.type) {

--- a/web/src/domain/translator/TranslationTask/types.ts
+++ b/web/src/domain/translator/TranslationTask/types.ts
@@ -27,3 +27,5 @@ export interface TranslationTask {
     translated: string[],
   ): Promise<void>;
 }
+
+export type TranslatorId = 'gpt' | 'sakura';

--- a/web/src/model/Translator.ts
+++ b/web/src/model/Translator.ts
@@ -8,6 +8,7 @@ export interface GptWorker {
   endpoint: string;
   model: string;
   key: string;
+  concurrency?: number;
 }
 
 export interface GptPipelineWorker extends GptWorker {
@@ -18,6 +19,7 @@ export interface GptPipelineWorker extends GptWorker {
 export interface SakuraWorker {
   id: string;
   endpoint: string;
+  concurrency?: number;
   segLength?: number;
   prevSegLength?: number;
 }

--- a/web/src/pages/MainLayout.vue
+++ b/web/src/pages/MainLayout.vue
@@ -150,12 +150,16 @@ const menuOptions = computed<MenuOption[]>(() => {
           key: '/workspace/gpt',
         },
         {
+          label: renderLabel('Sakura工作区', '/workspace/sakura'),
+          key: '/workspace/sakura',
+        },
+        {
           label: renderLabel('GPT工作区BETA', '/workspace/gpt-pipeline'),
           key: '/workspace/gpt-pipeline',
         },
         {
-          label: renderLabel('Sakura工作区', '/workspace/sakura'),
-          key: '/workspace/sakura',
+          label: renderLabel('Sakura工作区BETA', '/workspace/sakura-pipeline'),
+          key: '/workspace/sakura-pipeline',
         },
         {
           label: renderLabel('交互翻译', '/workspace/interactive'),

--- a/web/src/pages/workspace/GptPipelineWorkspace.vue
+++ b/web/src/pages/workspace/GptPipelineWorkspace.vue
@@ -9,26 +9,43 @@ import { VueDraggable } from 'vue-draggable-plus';
 import {
   Semaphore,
   OpenAiTranslator,
+  SakuraTranslator,
   TranslationPipeline,
 } from '@auto-novel/translator';
 import type { TranslatorTracker } from '@auto-novel/translator';
 
 import { doAction } from '@/pages/util';
-import { useGptPipelineWorkspaceStore, useWorkspaceStore } from '@/stores';
+import { useWorkspaceStore } from '@/stores';
 import { TaskExecutor } from '@/domain/translator/TaskExecutor';
 import { IndexedDbSegmentCache } from '@/domain/translator/IndexedDbSegmentCache';
 import { createTranslationTask } from '@/domain/translator/TranslationTask/createTranslationTask';
-import type { TranslationTask } from '@/domain/translator/TranslationTask/types';
+import type {
+  TranslationTask,
+  TranslatorId,
+} from '@/domain/translator/TranslationTask/types';
 import { TaskState } from '@/domain/translator/TaskState';
 import type { ChapterStatus } from '@/domain/translator/TaskState';
-import type { TranslateJob, TranslateJobRecord } from '@/model/Translator';
+import type {
+  GptPipelineWorker,
+  SakuraWorker,
+  TranslateJob,
+  TranslateJobRecord,
+} from '@/model/Translator';
 import { TranslateTaskDescriptor } from '@/model/Translator';
 import PipelineTaskCard from './components/PipelineTaskCard.vue';
 
+const props = defineProps<{ translatorId: TranslatorId }>();
 const message = useMessage();
-const pipelineWorkspace = useGptPipelineWorkspaceStore();
-const gptWorkspace = useWorkspaceStore('gpt'); // 暂时与旧版 GPT 共享任务队列
-const jobs = computed(() => gptWorkspace.ref.value.jobs);
+
+const isSakura = computed(() => props.translatorId === 'sakura');
+const segCacheName = isSakura.value ? 'sakura-seg-cache' : 'gpt-seg-cache';
+
+const workerStore = useWorkspaceStore(
+  isSakura.value ? 'sakura' : 'gpt-pipeline',
+);
+const jobStore = useWorkspaceStore(props.translatorId);
+
+const jobs = computed(() => jobStore.ref.value.jobs);
 
 const showWorkerModal = ref(false);
 const showLocalVolumeDrawer = ref(false);
@@ -43,7 +60,8 @@ const HIGH_WATER_MARK = 100;
 const pipeline = new TranslationPipeline(
   HIGH_WATER_MARK,
   undefined,
-  new IndexedDbSegmentCache('gpt-seg-cache'),
+  new IndexedDbSegmentCache(segCacheName),
+  isSakura.value ? 'chapter' : 'segment',
 );
 
 // ========== 任务状态管理 ==========
@@ -55,6 +73,7 @@ const taskVersions = ref(new Map<string, number>());
 interface WorkerState {
   running: boolean;
   concurrency: { current: number; max: number };
+  allowUpload?: boolean;
 }
 const workerStates = ref(new Map<string, WorkerState>());
 const workerErrors = computed(() => {
@@ -77,10 +96,12 @@ let processLoopPromise: Promise<void> | null = null;
 
 onUnmounted(() => {
   pipeline.clearLoops();
+  pipeline.queue.clear();
   processLoopAbortController?.abort();
   processLoopAbortController = null;
   processLoopPromise = null;
   executingTasks.clear();
+  workerStates.value.clear();
 });
 // ========== 任务过滤 ==========
 
@@ -107,7 +128,7 @@ async function getOrCreateTask(taskDesc: string): Promise<TranslationTask> {
   let task = taskCache.get(taskDesc);
   if (!task) {
     const { desc, params } = TranslateTaskDescriptor.parse(taskDesc);
-    task = createTranslationTask(desc, 'gpt', params);
+    task = createTranslationTask(desc, props.translatorId, params);
     taskCache.set(taskDesc, task);
   }
   return task;
@@ -176,7 +197,11 @@ function runProcessLoop(): Promise<void> | null {
       executingTasks.add(job.task);
 
       const task = await getOrCreateTask(job.task);
-      const executor = new TaskExecutor(task, pipeline, fetchSemaphore);
+      const executor = new TaskExecutor(task, pipeline, fetchSemaphore, () =>
+        [...workerStates.value.values()].every(
+          (s) => !s.running || s.allowUpload !== false,
+        ),
+      );
 
       const segmentTracker = state.getChapterState(chapterId);
       if (!segmentTracker) continue;
@@ -230,36 +255,43 @@ function runProcessLoop(): Promise<void> | null {
 
 // ========== Worker 生命周期管理 ==========
 
-const startWorker = (workerId: string) => {
+const startWorker = async (workerId: string) => {
   if (workerStates.value.get(workerId)?.running) return;
 
-  const w = pipelineWorkspace.ref.value.workers.find((w) => w.id === workerId);
+  const w = workerStore.ref.value.workers.find((w) => w.id === workerId);
   if (!w) {
     message.error(`翻译器 ${workerId} 不存在`);
     return;
   }
 
-  workerStates.value.set(workerId, {
+  const state = reactive<WorkerState>({
     running: true,
-    concurrency: { current: 0, max: w.concurrency },
+    concurrency: { current: 0, max: w.concurrency ?? 1 },
   });
+  workerStates.value.set(workerId, state);
 
-  const t = new OpenAiTranslator({
-    endpoint: w.endpoint,
-    key: w.key,
-    model: w.model,
-    profile: w.profile,
-  });
+  try {
+    const t = isSakura.value
+      ? await SakuraTranslator.create(w as SakuraWorker)
+      : new OpenAiTranslator(w as GptPipelineWorker);
 
-  const workerTracker: TranslatorTracker = {
-    onConcurrencyChange: (current: number, max: number) => {
-      const state = workerStates.value.get(w.id);
-      if (state) state.concurrency = { current, max };
-    },
-  };
-  pipeline.registerTranslator(t, w.concurrency, workerTracker, w.id);
+    if (workerStates.value.get(workerId) !== state) return;
 
-  runProcessLoop();
+    state.allowUpload = !(t instanceof SakuraTranslator) || t.allowUpload();
+
+    const workerTracker: TranslatorTracker = {
+      onConcurrencyChange: (current: number, max: number) => {
+        state.concurrency = { current, max };
+      },
+    };
+    pipeline.registerTranslator(t, w.concurrency, workerTracker, w.id);
+
+    runProcessLoop();
+  } catch (e) {
+    if (workerStates.value.get(workerId) !== state) return;
+    stopWorker(workerId);
+    message.error(`翻译器启动失败：${e}`);
+  }
 };
 
 const stopWorker = (workerId: string) => {
@@ -273,16 +305,16 @@ const stopWorker = (workerId: string) => {
   if ([...workerStates.value.values()].every((s) => !s.running)) {
     processLoopAbortController?.abort();
     processLoopAbortController = null;
-    processLoopPromise = null;
+    pipeline.queue.clear();
   }
 };
 
 const startAllWorkers = () => {
-  for (const w of pipelineWorkspace.ref.value.workers) startWorker(w.id);
+  for (const w of workerStore.ref.value.workers) startWorker(w.id);
 };
 
 const stopAllWorkers = () => {
-  for (const w of pipelineWorkspace.ref.value.workers) stopWorker(w.id);
+  for (const w of workerStore.ref.value.workers) stopWorker(w.id);
 };
 
 const deleteJob = (task: string) => {
@@ -290,7 +322,7 @@ const deleteJob = (task: string) => {
     message.error('任务正在翻译中');
     return;
   }
-  gptWorkspace.deleteJob(task);
+  jobStore.deleteJob(task);
   clearTaskRuntimeState(task);
 };
 
@@ -313,7 +345,7 @@ function retryTaskCards() {
 
 const clearCache = () =>
   doAction(
-    new IndexedDbSegmentCache('gpt-seg-cache').clear(),
+    new IndexedDbSegmentCache(segCacheName).clear(),
     '缓存清除',
     message,
   );
@@ -387,10 +419,10 @@ watch(
 
 <template>
   <div class="layout-content">
-    <n-h1>GPT工作区BETA</n-h1>
+    <n-h1>{{ isSakura ? 'Sakura' : 'GPT' }}工作区BETA</n-h1>
     <bulletin>
       <n-p>
-        支持并发和查看章节分块状态的新GPT工作区。目前处于测试阶段，有问题请在群内反馈。
+        支持并发和查看章节分块状态的新工作区。目前处于测试阶段，有问题请在群内反馈。
       </n-p>
     </bulletin>
 
@@ -419,34 +451,35 @@ watch(
     </n-flex>
 
     <n-empty
-      v-if="pipelineWorkspace.ref.value.workers.length === 0"
+      v-if="workerStore.ref.value.workers.length === 0"
       description="没有翻译器"
     />
     <n-list v-else class="worker-list">
       <vue-draggable
-        v-model="pipelineWorkspace.ref.value.workers"
+        v-model="workerStore.ref.value.workers"
         :animation="150"
         handle=".drag-trigger"
         filter=".is-running"
       >
         <n-list-item
-          v-for="w of pipelineWorkspace.ref.value.workers"
+          v-for="w of workerStore.ref.value.workers"
           :key="w.id"
           :class="{ 'is-running': workerStates.get(w.id)?.running }"
         >
           <pipeline-worker-card
+            :translator-id="translatorId"
             :worker="w"
             :running="!!workerStates.get(w.id)?.running"
             :concurrency="
               workerStates.get(w.id)?.concurrency ?? {
                 current: 0,
-                max: w.concurrency,
+                max: w.concurrency ?? 1,
               }
             "
             :error-count="workerErrors.get(w.id) ?? 0"
             @start="startWorker"
             @stop="stopWorker"
-            @delete="pipelineWorkspace.deleteWorker"
+            @delete="workerStore.deleteWorker"
           />
         </n-list-item>
       </vue-draggable>
@@ -494,19 +527,20 @@ watch(
         ref="taskCardRefs"
         :key="job.task"
         :job="job"
+        :translator-id="translatorId"
         :task-state="taskStates.get(job.task)"
         :task-cache-entry="taskCache.get(job.task)"
         @delete="deleteJob"
         @retry="(task: string) => runProcessLoop()"
         @top="
           (task: string) =>
-            gptWorkspace.topJob(
+            jobStore.topJob(
               jobs.find((j: { task: string }) => j.task === task)!,
             )
         "
         @bottom="
           (task: string) =>
-            gptWorkspace.bottomJob(
+            jobStore.bottomJob(
               jobs.find((j: { task: string }) => j.task === task)!,
             )
         "
@@ -516,9 +550,10 @@ watch(
 
   <local-volume-list-specific-translation
     v-model:show="showLocalVolumeDrawer"
-    type="gpt"
+    :type="translatorId"
   />
-  <gpt-pipeline-worker-modal v-model:show="showWorkerModal" />
+  <sakura-worker-modal v-if="isSakura" v-model:show="showWorkerModal" />
+  <gpt-pipeline-worker-modal v-else v-model:show="showWorkerModal" />
 </template>
 
 <style scoped>

--- a/web/src/pages/workspace/components/PipelineTaskCard.vue
+++ b/web/src/pages/workspace/components/PipelineTaskCard.vue
@@ -11,10 +11,14 @@ import { TaskState, ChapterSegmentState } from '@/domain/translator/TaskState';
 import type { TranslateJob, TranslateJobRecord } from '@/model/Translator';
 import { TranslateTaskDescriptor } from '@/model/Translator';
 import { createTranslationTask } from '@/domain/translator/TranslationTask/createTranslationTask';
-import type { TranslationTask } from '@/domain/translator/TranslationTask/types';
+import type {
+  TranslationTask,
+  TranslatorId,
+} from '@/domain/translator/TranslationTask/types';
 
 const props = defineProps<{
   job: TranslateJob;
+  translatorId: TranslatorId;
   taskState?: TaskState;
   taskCacheEntry?: TranslationTask;
 }>();
@@ -93,7 +97,7 @@ const message = useMessage();
 
 function createTask(taskDesc: string): TranslationTask {
   const { desc, params } = TranslateTaskDescriptor.parse(taskDesc);
-  return createTranslationTask(desc, 'gpt', params);
+  return createTranslationTask(desc, props.translatorId, params);
 }
 
 const showPreview = ref(false);

--- a/web/src/pages/workspace/components/PipelineWorkerCard.vue
+++ b/web/src/pages/workspace/components/PipelineWorkerCard.vue
@@ -7,11 +7,13 @@ import {
   SettingsOutlined,
   StopOutlined,
 } from '@vicons/material';
-import { OpenAiTranslator } from '@auto-novel/translator';
-import type { GptPipelineWorker } from '@/model/Translator';
+import { OpenAiTranslator, SakuraTranslator } from '@auto-novel/translator';
+import type { GptPipelineWorker, SakuraWorker } from '@/model/Translator';
+import type { TranslatorId } from '@/domain/translator/TranslationTask/types';
 
 const props = defineProps<{
-  worker: GptPipelineWorker;
+  translatorId: TranslatorId;
+  worker: GptPipelineWorker | SakuraWorker;
   running: boolean;
   concurrency: { current: number; max: number };
   errorCount: number;
@@ -38,15 +40,16 @@ const testWorker = async () => {
   ];
   const reasoningLogs: string[] = [];
   try {
-    const translator = new OpenAiTranslator({
-      endpoint: props.worker.endpoint,
-      key: props.worker.key,
-      model: props.worker.model,
-      profile: props.worker.profile,
-      log: (msg) => {
-        if (msg.startsWith('思考：')) reasoningLogs.push(msg);
-      },
-    });
+    const translator =
+      props.translatorId === 'sakura'
+        ? await SakuraTranslator.create(props.worker)
+        : new OpenAiTranslator({
+            ...(props.worker as GptPipelineWorker),
+            log: (msg) => {
+              if (msg.startsWith('思考：')) reasoningLogs.push(msg);
+            },
+          });
+
     const textZh = await translator.translate(
       textJp,
       undefined,
@@ -76,7 +79,12 @@ const testWorker = async () => {
     <template #header>
       {{ worker.id }}
       <n-text depth="3" style="font-size: 12px; padding-left: 2px">
-        {{ worker.model }}[{{ worker.key.slice(-4) }}]@{{ worker.endpoint }}
+        <template v-if="translatorId === 'gpt'">
+          {{ (worker as GptPipelineWorker).model }}[{{
+            (worker as GptPipelineWorker).key.slice(-4)
+          }}]@
+        </template>
+        {{ worker.endpoint }}
       </n-text>
       <span class="viz-translator" style="margin-left: 6px">
         <n-text depth="3" class="viz-concurrency-num">
@@ -135,8 +143,14 @@ const testWorker = async () => {
   </n-thing>
 
   <gpt-pipeline-worker-modal
+    v-if="translatorId === 'gpt'"
     v-model:show="showEditModal"
-    :worker="showEditModal ? worker : undefined"
+    :worker="showEditModal ? (worker as GptPipelineWorker) : undefined"
+  />
+  <sakura-worker-modal
+    v-else-if="showEditModal"
+    v-model:show="showEditModal"
+    :worker="worker"
   />
 </template>
 

--- a/web/src/pages/workspace/components/SakuraWorkerModal.vue
+++ b/web/src/pages/workspace/components/SakuraWorkerModal.vue
@@ -17,19 +17,14 @@ const workspace = useSakuraWorkspaceStore();
 const workspaceRef = workspace.ref;
 const message = useMessage();
 
-const initFormValue = () => {
-  const worker = props.worker;
-  if (worker === undefined) {
-    return {
-      id: '',
-      endpoint: '',
-      segLength: 500,
-      prevSegLength: 500,
-    };
-  } else {
-    return { ...worker };
-  }
-};
+const initFormValue = () => ({
+  id: '',
+  endpoint: '',
+  segLength: 500,
+  prevSegLength: 500,
+  ...props.worker,
+  concurrency: props.worker?.concurrency ?? 1,
+});
 
 const formRef = useTemplateRef<FormInst>('form');
 const formValue = ref(initFormValue());
@@ -143,6 +138,16 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
         />
       </n-form-item-row>
 
+      <n-form-item-row path="concurrency" label="并发数">
+        <n-input-number
+          :value="formValue.concurrency"
+          :min="1"
+          :max="100"
+          :precision="0"
+          @update:value="(value) => (formValue.concurrency = value ?? 1)"
+        />
+      </n-form-item-row>
+
       <n-form-item-row path="segLength" label="分段长度">
         <n-input-number
           v-model:value="formValue.segLength"
@@ -167,6 +172,10 @@ const verb = computed(() => (props.worker === undefined ? '添加' : '更新'));
         # 分段长度还在测试中，非默认500无法上传
         <br />
         # 链接例子：http://127.0.0.1:8080
+      </n-text>
+      <br />
+      <n-text depth="3" style="font-size: 12px">
+        # 并发数仅beta工作区生效，是章节级别的并发。
       </n-text>
     </n-form>
 

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -192,15 +192,23 @@ const router = createRouter({
               component: () => import('./pages/workspace/GptWorkspace.vue'),
             },
             {
+              path: 'sakura',
+              meta: { title: 'Sakura工作区' },
+              component: () => import('./pages/workspace/SakuraWorkspace.vue'),
+            },
+            {
               path: 'gpt-pipeline',
               meta: { title: 'GPT工作区BETA' },
               component: () =>
                 import('./pages/workspace/GptPipelineWorkspace.vue'),
+              props: { translatorId: 'gpt', key: 'gpt-pipeline' },
             },
             {
-              path: 'sakura',
-              meta: { title: 'Sakura工作区' },
-              component: () => import('./pages/workspace/SakuraWorkspace.vue'),
+              path: 'sakura-pipeline',
+              meta: { title: 'Sakura工作区BETA' },
+              component: () =>
+                import('./pages/workspace/GptPipelineWorkspace.vue'),
+              props: { translatorId: 'sakura', key: 'sakura-pipeline' },
             },
             {
               path: 'interactive',


### PR DESCRIPTION
为 GPT Beta 工作区和 translator package 增加 Sakura 支持，新增 Sakura Beta 工作区，复用现有 GPT Beta 的 UI，并与原 Sakura 工作区共用 store。

支持章节级并发：不同章节并发翻译，同一章节按 (链表) segment → next segment 顺序执行。当前分段成功后，下一分段优先入队，并携带此前分段的译文作为前文；任一分段失败，该章后续分段停止翻译。(前文的传入处理参考旧 Sakura 的实现)

上传校验在每章开始时执行：存在运行中且明确未通过上传检查的翻译器时，网络／文库章节直接报错，本地任务正常执行。已通过检查的章节不重复校验。